### PR TITLE
Bug/names

### DIFF
--- a/load/graph.go
+++ b/load/graph.go
@@ -61,7 +61,7 @@ func (g *Graph) load() error {
 
 		if parent, ok := id.Resource.(resource.Parent); ok {
 			for _, child := range parent.Children() {
-				childID := ident{id.ID + graphIDSeparator + resource.LongName(child), child}
+				childID := ident{id.ID + graphIDSeparator + child.Name(), child}
 				g.graph.Add(childID.ID)
 				g.graph.Connect(dag.BasicEdge(id.ID, childID.ID))
 				ids = append(ids, childID)
@@ -77,7 +77,6 @@ func (g *Graph) load() error {
 	}
 
 	return g.graph.Validate()
-
 }
 
 func (g *Graph) String() string {
@@ -92,7 +91,7 @@ func (g *Graph) GraphString() string {
 		s += fmt.Sprintf(
 			"  \"%s\"[label=\"%s\"];\n",
 			node,
-			resource.LongName(g.resources[node.(string)]),
+			g.resources[node.(string)].Name(),
 		)
 	}
 

--- a/load/graph_test.go
+++ b/load/graph_test.go
@@ -78,11 +78,11 @@ func TestGraphWalk(t *testing.T) {
 		t,
 		[]string{
 			"test",
+			"test/test2",
+			"test/test2/template.template2",
+			"test/test2/task.task2",
 			"test/template.template",
 			"test/task.task",
-			"test/module.test2",
-			"test/module.test2/template.template2",
-			"test/module.test2/task.task2",
 		},
 		results,
 	)

--- a/load/parse_test.go
+++ b/load/parse_test.go
@@ -57,7 +57,7 @@ func TestDependentCall(t *testing.T) {
 	//Test DependentCall
 	mod, err := load.Parse([]byte(dependentCall))
 	assert.NoError(t, err)
-	assert.Equal(t, "module_task.y", getAllDeps(mod)[0])
+	assert.Equal(t, "y", getAllDeps(mod)[0])
 }
 
 //TestAutoDependencies test that if the depends field is not set for a Task,
@@ -79,11 +79,15 @@ func TestAutoDependencies(t *testing.T) {
 
 }
 
-func TestSameNameDependencies(t *testing.T) {
-	//t.Parallel()
+func TestSameNameDependencies_Wrong(t *testing.T) {
+	t.Parallel()
 	_, err := load.Parse([]byte(sameNameDependenciesWrong))
 	assert.Error(t, err)
-	_, err = load.Parse([]byte(sameNameDependenciesRight))
+}
+
+func TestSameNameDependencies_Right(t *testing.T) {
+	t.Parallel()
+	_, err := load.Parse([]byte(sameNameDependenciesRight))
 	assert.NoError(t, err)
 }
 
@@ -101,7 +105,7 @@ func TestParseDuplicateParam(t *testing.T) {
 
 	_, err := load.Parse([]byte(duplicateParam))
 	if assert.Error(t, err) {
-		assert.EqualError(t, err, "At 3:1: duplicate param \"x\"")
+		assert.EqualError(t, err, "At 3:1: duplicate param \"param.x\"")
 	}
 }
 
@@ -136,7 +140,7 @@ func TestParseDuplicateTask(t *testing.T) {
 
 	_, err := load.Parse([]byte(duplicateTask))
 	if assert.Error(t, err) {
-		assert.EqualError(t, err, "At 3:1: duplicate task \"x\"")
+		assert.EqualError(t, err, "At 3:1: duplicate task \"task.x\"")
 	}
 }
 
@@ -145,7 +149,7 @@ func TestBadName(t *testing.T) {
 
 	_, err := load.Parse([]byte(badName))
 	if assert.Error(t, err) {
-		assert.EqualError(t, err, `At 2:1: invalid name "a b"`)
+		assert.EqualError(t, err, `At 2:1: invalid name "task.a b"`)
 	}
 }
 
@@ -181,35 +185,35 @@ task "permission" {
 	task "render" {
 	  check = "cat {{param 'filename'}} | tee /dev/stderr | grep -q '{{param 'message'}}'"
 	  apply = "echo '{{param 'message'}}' > {{param 'filename'}} && cat {{param 'filename'}}"
-	  depends = ["nothing", "morenothing"]
+	  depends = ["task.nothing", "task.morenothing"]
 	}
 
 `
 
 	emptyDependenciesModule = `
-param "filename" { }
-param "permissions" { default = "0600" }
+	param "filename" { }
+	param "permissions" { default = "0600" }
 
-template "test" {
-content = ""
-}
-task "permission" {
-  check = "stat -f \"test%Op\" {{param \"filename\"}} tee /dev/stderr | grep -q {{param \"permission\"}}"
-  apply = "chmod {{param \"permission\"}} {{param \"filename\"}}"
-	depends = []
-}
+	template "test" {
+		content = ""
+	}
+	task "permission" {
+	  check = "stat -f \"test%Op\" {{param \"filename\"}} tee /dev/stderr | grep -q {{param \"permission\"}}"
+	  apply = "chmod {{param \"permission\"}} {{param \"filename\"}}"
+		depends = []
+	}
 `
 
 	taskDependenciesModule = `
 	task "a" {
-	check = ""
-	apply = ""
-}
+		check = ""
+		apply = ""
+	}
 
 	task "b" {
-	check = ""
-	apply = ""
-}
+		check = ""
+		apply = ""
+	}
 
 	task "c" {
 		check = ""
@@ -219,37 +223,37 @@ task "permission" {
 `
 
 	sameNameDependenciesWrong = `
-template "a" {
-content = ""
-}
+	template "a" {
+		content = ""
+	}
 
-task "a" {
-check = ""
-apply = ""
-}
+	task "a" {
+		check = ""
+		apply = ""
+	}
 
-task "c" {
-	check = ""
-	apply = ""
-	depends = ["a"]
-}
+	task "c" {
+		check = ""
+		apply = ""
+		depends = ["a"]
+	}
 `
 
 	sameNameDependenciesRight = `
-template "a" {
-content = ""
-}
+	template "a" {
+		content = ""
+	}
 
-task "a" {
-check = ""
-apply = ""
-}
+	task "a" {
+		check = ""
+		apply = ""
+	}
 
-task "c" {
-check = ""
-apply = ""
-depends = ["template.a"]
-}
+	task "c" {
+		check = ""
+		apply = ""
+		depends = ["template.a"]
+	}
 `
 
 	duplicateParam = `
@@ -265,17 +269,17 @@ module "x" "y" {
 
 	dependentCall = `
 	module "x" "y" {
-	params = {
-		arg1 = "z"
+		params = {
+			arg1 = "z"
+		}
 	}
-}
 
 	module "a" "b" {
-	params = {
-		arg1 = "z"
-	}
-	depends = ["y"]
-}`
+		params = {
+			arg1 = "z"
+		}
+		depends = ["y"]
+	}`
 
 	duplicateTask = `
 task "x" { }

--- a/resource/module.go
+++ b/resource/module.go
@@ -56,7 +56,7 @@ func (m *Module) Params() map[string]*Param {
 
 	for _, res := range m.Resources {
 		if param, ok := res.(*Param); ok {
-			params[param.Name()] = param
+			params[param.ParamName] = param
 		}
 	}
 

--- a/resource/param.go
+++ b/resource/param.go
@@ -46,9 +46,9 @@ func (v ValidationError) Error() string {
 	return fmt.Sprintf("%s: %s", v.Location, v.Err)
 }
 
-// Name returns the name of this param
+// Name returns the fully qualified name of this param
 func (p *Param) Name() string {
-	return p.ParamName
+	return "param." + p.ParamName
 }
 
 // Validate that this value is correct

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -14,11 +14,6 @@
 
 package resource
 
-import (
-	"fmt"
-	"regexp"
-)
-
 // Monitor checks if a resource is correct.
 type Monitor interface {
 	Check() (string, bool, error)
@@ -44,37 +39,4 @@ type Resource interface {
 // executable
 type Parent interface {
 	Children() []Resource
-}
-
-//LongName returns the name of the resource wrapped around its type
-//e.g template(a)
-func LongName(res Resource) string {
-	switch res.(type) {
-	case *Module:
-		return fmt.Sprintf("module.%s", res.Name())
-	case *ModuleTask:
-		return fmt.Sprintf("module.%s", res.Name())
-	case *Template:
-		return fmt.Sprintf("template.%s", res.Name())
-	case *Param:
-		return fmt.Sprintf("param.%s", res.Name())
-	case Task:
-		return fmt.Sprintf("task.%s", res.Name())
-	case Monitor:
-		return fmt.Sprintf("monitor.%s", res.Name())
-	}
-	return fmt.Sprintf("unsupported.%s", res.Name())
-}
-
-var shortNameRegex = regexp.MustCompile(`\w+\.(\w+)`)
-
-//ShortName returns the name of a Resource
-//If longName = "type(a)" it returns "a" otherwise it
-//returns longName
-func ShortName(longName string) string {
-	res := shortNameRegex.FindStringSubmatch(longName)
-	if res == nil || res[1] == "" {
-		return longName
-	}
-	return res[1]
 }

--- a/resource/shelltask.go
+++ b/resource/shelltask.go
@@ -33,7 +33,7 @@ type ShellTask struct {
 
 // Name returns name for metadata
 func (st *ShellTask) Name() string {
-	return st.TaskName
+	return "task." + st.TaskName
 }
 
 // Validate checks shell tasks validity

--- a/resource/template.go
+++ b/resource/template.go
@@ -31,7 +31,7 @@ type Template struct {
 
 // Name returns the name of this template
 func (t *Template) Name() string {
-	return t.TemplateName
+	return "template." + t.TemplateName
 }
 
 // Validate validates the template config

--- a/samples/basicDependencies.hcl
+++ b/samples/basicDependencies.hcl
@@ -14,5 +14,5 @@ task "nothing" {
 task "render" {
   check   = "cat {{param `filename`}} | tee /dev/stderr | grep -q '{{param `message`}}'"
   apply   = "echo '{{param `message`}}' > {{param `filename`}} && cat {{param `filename`}}"
-  depends = ["nothing"]
+  depends = ["task.nothing"]
 }

--- a/samples/requirementsOrderSmall.hcl
+++ b/samples/requirementsOrderSmall.hcl
@@ -2,20 +2,20 @@ task "a" {
   check = ""
   apply = ""
 
-  depends = ["b", "c"]
+  depends = ["task.b", "task.c"]
 }
 
 task "b" {
   check = ""
   apply = ""
 
-  depends = ["d"]
+  depends = ["task.d"]
 }
 
 task "c" {
   check   = ""
   apply   = ""
-  depends = ["d"]
+  depends = ["task.d"]
 }
 
 task "d" {


### PR DESCRIPTION
Pull request for issue #56 
Graph nodes now in the form resource_type.name.
Example: 
![Imgur](http://i.imgur.com/ljgyJ4I.png)
