### PR TITLE
dependency tracker

### DIFF
--- a/load/load.go
+++ b/load/load.go
@@ -61,7 +61,10 @@ func Load(source string, args resource.Values) (*Graph, error) {
 				newModule.Args = mt.Args
 				newModule.Source = mt.Source
 				newModule.ModuleName = mt.ModuleName
-				newModule.Dependencies = append(newModule.Dependencies, mt.Dependencies...)
+				newModule.SetDepends(append(
+					newModule.Depends(),
+					mt.Depends()...,
+				))
 
 				module.Resources[i] = newModule
 				modules = append(modules, newModule)

--- a/load/parse.go
+++ b/load/parse.go
@@ -68,8 +68,7 @@ func parseModule(node ast.Node) (*resource.Module, error) {
 
 				// If no requirements are specified, it is assumed that the task before
 				// the current task is the only requirement
-				// See https://github.com/asteris-llc/converge/issues/10
-				if previousTaskName != "" && res.Depends() == nil {
+				if previousTaskName != "" && !res.HasBaseDependencies() {
 					res.SetDepends([]string{previousTaskName})
 				}
 				previousTaskName = res.String()

--- a/resource/builtin/file/mode.go
+++ b/resource/builtin/file/mode.go
@@ -23,6 +23,8 @@ import (
 
 // Mode controls file mode of underlying resources
 type Mode struct {
+	resource.DependencyTracker `hcl:",squash"`
+
 	Name           string
 	RawDestination string   `hcl:"destination"`
 	RawMode        string   `hcl:"mode"`
@@ -69,16 +71,6 @@ func (m *Mode) Prepare(parent *resource.Module) (err error) {
 
 func (m *Mode) String() string {
 	return "file.mode." + m.Name
-}
-
-// Depends returns the set of dependencies
-func (m *Mode) Depends() []string {
-	return m.Dependencies
-}
-
-// SetDepends sets the set of dependencies
-func (m *Mode) SetDepends(new []string) {
-	m.Dependencies = new
 }
 
 // SetName modifies the name of this mode

--- a/resource/dependencytracker.go
+++ b/resource/dependencytracker.go
@@ -1,0 +1,77 @@
+// Copyright © 2016 Asteris, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resource
+
+// DependencyTracker is an embedded behavior for tracking dependencies.
+type DependencyTracker struct {
+	BaseItems     *[]string `hcl:"depends"`
+	ComputedItems []string
+}
+
+// SetDepends sets the list of provided dependencies
+func (dt *DependencyTracker) SetDepends(items []string) {
+	dt.BaseItems = &items
+}
+
+// HasBaseDependencies indicates if BaseItems is set
+func (dt *DependencyTracker) HasBaseDependencies() bool {
+	return dt.BaseItems != nil
+}
+
+// Depends lists tracked dependencies
+func (dt *DependencyTracker) Depends() []string {
+	var base []string
+	if dt.BaseItems != nil {
+		base = *dt.BaseItems
+	}
+
+	return dt.dedupe(
+		base,
+		dt.ComputedItems,
+	)
+}
+
+// ComputeDependencies for the given strings
+func (dt *DependencyTracker) ComputeDependencies(name string, renderer *Renderer, sources ...string) error {
+	results := [][]string{}
+
+	for _, source := range sources {
+		result, err := renderer.Params(name, source)
+		if err != nil {
+			return err
+		}
+
+		results = append(results, result)
+	}
+
+	dt.ComputedItems = dt.dedupe(results...)
+	return nil
+}
+
+func (dt *DependencyTracker) dedupe(sources ...[]string) (out []string) {
+	dest := map[string]struct{}{}
+
+	for _, source := range sources {
+		for _, item := range source {
+			dest[item] = struct{}{}
+		}
+	}
+
+	for k := range dest {
+		out = append(out, k)
+	}
+
+	return out
+}

--- a/resource/dependencytracker_test.go
+++ b/resource/dependencytracker_test.go
@@ -1,0 +1,89 @@
+// Copyright © 2016 Asteris, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resource_test
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/asteris-llc/converge/resource"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDependencyTrackerSetDepends(t *testing.T) {
+	t.Parallel()
+
+	tracker := new(resource.DependencyTracker)
+	tracker.SetDepends([]string{"test"})
+
+	assert.Equal(t, []string{"test"}, *tracker.BaseItems)
+}
+
+func TestDependencyTrackerDepends(t *testing.T) {
+	t.Parallel()
+
+	tracker := &resource.DependencyTracker{
+		BaseItems:     &[]string{"a"},
+		ComputedItems: []string{"b"},
+	}
+	deps := tracker.Depends()
+	sort.Strings(deps)
+
+	assert.Equal(
+		t,
+		[]string{"a", "b"},
+		deps,
+	)
+}
+
+func TestDependencyTrackerDependsDeduplicates(t *testing.T) {
+	t.Parallel()
+
+	tracker := &resource.DependencyTracker{
+		BaseItems:     &[]string{"a"},
+		ComputedItems: []string{"a"},
+	}
+
+	assert.Equal(
+		t,
+		[]string{"a"},
+		tracker.Depends(),
+	)
+}
+
+func TestDependencyTrackerComputeDependencies(t *testing.T) {
+	t.Parallel()
+
+	renderer, err := resource.NewRenderer(&resource.Module{
+		Resources: []resource.Resource{
+			&resource.Param{Name: "test"},
+		},
+	})
+	require.NoError(t, err)
+
+	tracker := new(resource.DependencyTracker)
+	err = tracker.ComputeDependencies(
+		"test",
+		renderer,
+		`{{param "test"}}`,
+	)
+	assert.NoError(t, err)
+	assert.Equal(
+		t,
+		[]string{"param.test"},
+		tracker.ComputedItems,
+	)
+}

--- a/resource/moduletask.go
+++ b/resource/moduletask.go
@@ -16,27 +16,16 @@ package resource
 
 // ModuleTask is the task for calling a module.
 type ModuleTask struct {
-	Args         Values `hcl:"params"`
-	Source       string
-	ModuleName   string
-	Dependencies []string `hcl:"depends"`
+	DependencyTracker `hcl:",squash"`
+
+	Args       Values `hcl:"params"`
+	Source     string
+	ModuleName string
 }
 
 // Name returns name for metadata
 func (m *ModuleTask) String() string {
 	return "module." + m.ModuleName
-}
-
-//SetDepends overwrites the Dependencies of this resource
-func (m *ModuleTask) SetDepends(deps []string) {
-	//Remove duplicateTask
-	m.Dependencies = deps
-}
-
-//Depends list dependencies for this task
-func (m *ModuleTask) Depends() []string {
-
-	return m.Dependencies
 }
 
 // Validate this module - these are replaced with Modules very early in the

--- a/resource/param.go
+++ b/resource/param.go
@@ -16,6 +16,8 @@ package resource
 
 // Param is essentially the calling arguments of a module
 type Param struct {
+	DependencyTracker `hcl:",squash"`
+
 	Name    string
 	Default Value  `hcl:"default"`
 	Type    string `hcl:"type"`
@@ -27,14 +29,6 @@ type Param struct {
 // interface.
 func (p *Param) String() string {
 	return "param." + p.Name
-}
-
-// SetDepends overwrites the Dependencies of this resource
-func (p *Param) SetDepends(deps []string) {}
-
-// Depends : Does nothing
-func (p *Param) Depends() []string {
-	return nil
 }
 
 // Prepare this module for use

--- a/resource/render.go
+++ b/resource/render.go
@@ -56,8 +56,8 @@ func (r *Renderer) Render(name, source string) (string, error) {
 	return buf.String(), nil
 }
 
-// Dependencies inside the template string
-func (r *Renderer) Dependencies(name string, base []string, sources ...string) ([]string, error) {
+// Params inside a string
+func (r *Renderer) Params(name, source string) ([]string, error) {
 	var (
 		out []string
 
@@ -77,20 +77,13 @@ func (r *Renderer) Dependencies(name string, base []string, sources ...string) (
 		}
 	)
 
-	// add the already known deps
-	for _, dep := range base {
-		deps[dep] = struct{}{}
+	tmpl, err := template.New(name).Funcs(funcs).Parse(source)
+	if err != nil {
+		return out, err
 	}
 
-	for _, source := range sources {
-		tmpl, err := template.New(name).Funcs(funcs).Parse(source)
-		if err != nil {
-			return out, err
-		}
-
-		if tmpl.Execute(ioutil.Discard, r.ctx) != nil {
-			return out, err
-		}
+	if err := tmpl.Execute(ioutil.Discard, r.ctx); err != nil {
+		return out, err
 	}
 
 	for dep := range deps {
@@ -98,6 +91,11 @@ func (r *Renderer) Dependencies(name string, base []string, sources ...string) (
 	}
 
 	return out, nil
+}
+
+// Dependencies inside the template string
+func (r *Renderer) Dependencies(name string, base []string, sources ...string) ([]string, error) {
+	return []string{}, nil
 }
 
 // Template Functions

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -36,6 +36,7 @@ type Resource interface {
 
 	Depends() []string
 	SetDepends([]string)
+	HasBaseDependencies() bool
 
 	SetName(string)
 }

--- a/resource/template.go
+++ b/resource/template.go
@@ -22,10 +22,11 @@ import (
 
 // Template is a task defined by content and a destination
 type Template struct {
+	DependencyTracker `hcl:",squash"`
+
 	Name           string
-	RawContent     string   `hcl:"content"`
-	RawDestination string   `hcl:"destination"`
-	Dependencies   []string `hcl:"depends"`
+	RawContent     string `hcl:"content"`
+	RawDestination string `hcl:"destination"`
 
 	renderer    *Renderer
 	content     string
@@ -35,16 +36,6 @@ type Template struct {
 // String returns the name of this template
 func (t *Template) String() string {
 	return "template." + t.Name
-}
-
-// SetDepends overwrites the Dependencies of this resource
-func (t *Template) SetDepends(deps []string) {
-	t.Dependencies = deps
-}
-
-// Depends list dependencies for this task
-func (t *Template) Depends() []string {
-	return t.Dependencies
 }
 
 // Check satisfies the Monitor interface
@@ -105,9 +96,9 @@ func (t *Template) Prepare(parent *Module) (err error) {
 	}
 
 	// get param dependencies
-	t.Dependencies, err = t.renderer.Dependencies(
+	err = t.DependencyTracker.ComputeDependencies(
 		t.String()+".dependencies",
-		t.Dependencies,
+		t.renderer,
 		t.RawContent,
 		t.RawDestination,
 	)


### PR DESCRIPTION
Previously, we'd have to implement `Dependencies []string` on each resource, plus `Depends` and `SetDepends`. Now we just have to embed `resource.DependencyTracker`.

This also fixed a few edge cases with automatic edge adding.
