### PR TITLE
resource(shell): add interpreter

### DIFF
--- a/resource/shell/preparer.go
+++ b/resource/shell/preparer.go
@@ -22,8 +22,9 @@ import (
 
 // Preparer for Shell tasks
 type Preparer struct {
-	Check string `hcl:"check"`
-	Apply string `hcl:"apply"`
+	Interpreter string `hcl:"interpreter"`
+	Check       string `hcl:"check"`
+	Apply       string `hcl:"apply"`
 }
 
 // Prepare a new task
@@ -46,7 +47,16 @@ func (p *Preparer) Prepare(render resource.Renderer) (resource.Task, error) {
 		return nil, err
 	}
 
-	return &Shell{check, apply}, nil
+	interpreter, err := render.Render("interpreter", p.Interpreter)
+	if err != nil {
+		return nil, err
+	}
+
+	if interpreter == "" {
+		interpreter = "sh" // TODO: make this work on Windows?
+	}
+
+	return &Shell{interpreter, check, apply}, nil
 }
 
 func (p *Preparer) validateScriptSyntax(script string) error {

--- a/resource/shell/shell.go
+++ b/resource/shell/shell.go
@@ -23,8 +23,9 @@ import (
 
 // Shell task
 type Shell struct {
-	CheckStmt string
-	ApplyStmt string
+	Interpreter string
+	CheckStmt   string
+	ApplyStmt   string
 }
 
 func (s *Shell) Check() (status string, willChange bool, err error) {
@@ -37,11 +38,12 @@ func (s *Shell) Apply() (err error) {
 	if code != 0 {
 		return fmt.Errorf("exit code %d, output: %q", code, out)
 	}
+
 	return err
 }
 
 func (s *Shell) exec(script string) (out string, code uint32, err error) {
-	command := exec.Command("sh")
+	command := exec.Command(s.Interpreter)
 	stdin, err := command.StdinPipe()
 	if err != nil {
 		return "", 0, err

--- a/resource/shell/shell_test.go
+++ b/resource/shell/shell_test.go
@@ -32,7 +32,8 @@ func TestShellTaskCheckNeedsChange(t *testing.T) {
 	t.Parallel()
 
 	s := shell.Shell{
-		CheckStmt: "echo test && exit 1",
+		Interpreter: "sh",
+		CheckStmt:   "echo test && exit 1",
 	}
 
 	current, change, err := s.Check()
@@ -45,7 +46,8 @@ func TestShellCheckNoChange(t *testing.T) {
 	t.Parallel()
 
 	s := shell.Shell{
-		CheckStmt: "echo test",
+		Interpreter: "sh",
+		CheckStmt:   "echo test",
 	}
 
 	current, change, err := s.Check()
@@ -58,7 +60,8 @@ func TestShellApplySuccess(t *testing.T) {
 	t.Parallel()
 
 	s := shell.Shell{
-		ApplyStmt: "echo test",
+		Interpreter: "sh",
+		ApplyStmt:   "echo test",
 	}
 
 	assert.NoError(t, s.Apply())
@@ -68,7 +71,8 @@ func TestShellTaskApplyError(t *testing.T) {
 	t.Parallel()
 
 	s := shell.Shell{
-		ApplyStmt: "echo bad && exit 1",
+		Interpreter: "sh",
+		ApplyStmt:   "echo bad && exit 1",
 	}
 
 	err := s.Apply()


### PR DESCRIPTION
adds configurable interpreter to shell resource. Defaults to `sh` in Preparer

@ajhager could you please take a look?
