### PR TITLE
env var and working dir support for shell tasks

### DIFF
--- a/resource/shell/preparer.go
+++ b/resource/shell/preparer.go
@@ -24,11 +24,12 @@ import (
 
 // Preparer for Shell tasks
 type Preparer struct {
-	Interpreter   string  `hcl:"interpreter"`
-	SyntaxChecker *string `hcl:"syntaxchecker"`
-	Check         string  `hcl:"check"`
-	Apply         string  `hcl:"apply"`
-	Dir           string  `hcl:"dir"`
+	Interpreter   string   `hcl:"interpreter"`
+	SyntaxChecker *string  `hcl:"syntaxchecker"`
+	Check         string   `hcl:"check"`
+	Apply         string   `hcl:"apply"`
+	Dir           string   `hcl:"dir"`
+	Env           []string `hcl:"env"`
 }
 
 // Prepare a new task
@@ -65,7 +66,18 @@ func (p *Preparer) Prepare(render resource.Renderer) (resource.Task, error) {
 		return nil, err
 	}
 
-	return &Shell{interpreter, check, apply, dir}, nil
+	// render Env
+	renderedEnv := make([]string, len(p.Env))
+	for i, envvar := range p.Env {
+		rendered, err := render.Render("env"+string(i), envvar)
+		if err != nil {
+			return nil, err
+		}
+
+		renderedEnv[i] = rendered
+	}
+
+	return &Shell{interpreter, check, apply, dir, renderedEnv}, nil
 }
 
 func (p *Preparer) validateScriptSyntax(script string) error {

--- a/resource/shell/preparer_test.go
+++ b/resource/shell/preparer_test.go
@@ -36,6 +36,7 @@ func TestPreparerValidateValid(t *testing.T) {
 		Check: "echo test",
 		Apply: "echo test",
 		Dir:   "/tmp/converge",
+		Env:   []string{"ROLE=test"},
 	}
 
 	_, err := sp.Prepare(fakerenderer.New())

--- a/resource/shell/shell.go
+++ b/resource/shell/shell.go
@@ -17,6 +17,7 @@ package shell
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"os/exec"
 	"syscall"
 )
@@ -27,6 +28,7 @@ type Shell struct {
 	CheckStmt   string
 	ApplyStmt   string
 	Dir         string
+	Env         []string
 }
 
 // Check system using CheckStmt
@@ -60,6 +62,14 @@ func (s *Shell) exec(script string) (out string, code uint32, err error) {
 	// setup command environment
 	if s.Dir != "" {
 		command.Dir = s.Dir
+	}
+
+	if len(s.Env) > 0 {
+		env := os.Environ()
+		for _, envvar := range s.Env {
+			env = append(env, envvar)
+		}
+		command.Env = env
 	}
 
 	if err = command.Start(); err != nil {


### PR DESCRIPTION
wip for #145. adds `env` and `dir` options to the shell module but doesn't address the broader idea of a context as discussed in #139.
