### PR TITLE
Shrink binaries with some magical ldflags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,7 @@ xcompile: test
 	@rm -rf build/
 	@mkdir -p build/
 	gox \
+    -ldflags="-s -w" \
 		-os="darwin" \
 		-os="linux" \
 		-os="freebsd" \


### PR DESCRIPTION
```
converge > make converge
go build -ldflags="-s -w" .

converge > go build -o converge.large .

converge > du -h converge*
7.4M    converge
 11M    converge.large
```
