### PR TITLE
Feature/optimize human printer

### DIFF
--- a/cmd/util.go
+++ b/cmd/util.go
@@ -46,6 +46,7 @@ func getPrinter() prettyprinters.Printer {
 
 	printer := human.NewFiltered(filter)
 	printer.Color = UseColor()
+	printer.InitColors()
 
 	return prettyprinters.New(printer)
 }

--- a/prettyprinters/human/human_test.go
+++ b/prettyprinters/human/human_test.go
@@ -26,6 +26,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var (
+	printer            = human.New()
+	printerOnlyChanged = human.NewFiltered(human.ShowOnlyChanged)
+	printerHideByKind  = human.NewFiltered(human.HideByKind("param"))
+)
+
 func TestSatisfiesInterface(t *testing.T) {
 	t.Parallel()
 
@@ -39,6 +45,7 @@ func testFinishPP(t *testing.T, in Printable, out string) {
 	g.Add("root", in)
 
 	printer := human.New()
+	printer.InitColors()
 	str, err := printer.FinishPP(g)
 
 	require.Nil(t, err)
@@ -66,9 +73,11 @@ func TestFinishPPError(t *testing.T) {
 }
 
 func testDrawNodes(t *testing.T, in Printable, out string) {
+	printer := human.New()
+	printer.InitColors()
 	testDrawNodesCustomPrinter(
 		t,
-		human.New(),
+		printer,
 		"root",
 		in,
 		out,
@@ -85,6 +94,21 @@ func testDrawNodesCustomPrinter(t *testing.T, h *human.Printer, id string, in Pr
 	assert.Equal(t, out, str.String())
 }
 
+func benchmarkDrawNodes(in Printable) {
+	benchmarkDrawNodesCustomPrinter(
+		printer,
+		"root",
+		in,
+	)
+}
+
+func benchmarkDrawNodesCustomPrinter(h *human.Printer, id string, in Printable) {
+	g := graph.New()
+	g.Add(id, in)
+
+	h.DrawNode(g, id)
+}
+
 func TestDrawNodeNoChanges(t *testing.T) {
 	t.Parallel()
 
@@ -95,28 +119,58 @@ func TestDrawNodeNoChanges(t *testing.T) {
 	)
 }
 
+func BenchmarkDrawNodeNoChanges(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		benchmarkDrawNodes(
+			Printable{},
+		)
+	}
+}
+
 func TestDrawNodeNoChangesFiltered(t *testing.T) {
 	t.Parallel()
+	printerOnlyChanged.InitColors()
 
 	testDrawNodesCustomPrinter(
 		t,
-		human.NewFiltered(human.ShowOnlyChanged),
+		printerOnlyChanged,
 		"root",
 		Printable{},
 		"",
 	)
 }
 
+func BenchmarkDrawNodeNoChangesFiltered(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		benchmarkDrawNodesCustomPrinter(
+			printerOnlyChanged,
+			"root",
+			Printable{},
+		)
+	}
+}
+
 func TestDrawNodeMetaFiltered(t *testing.T) {
 	t.Parallel()
+	printerHideByKind.InitColors()
 
 	testDrawNodesCustomPrinter(
 		t,
-		human.NewFiltered(human.HideByKind("param")),
+		printerHideByKind,
 		"param.test",
 		Printable{},
 		"",
 	)
+}
+
+func BenchmarkDrawNodeMetaFiltered(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		benchmarkDrawNodesCustomPrinter(
+			printerHideByKind,
+			"param.test",
+			Printable{},
+		)
+	}
 }
 
 func TestDrawNodeChanges(t *testing.T) {
@@ -129,6 +183,14 @@ func TestDrawNodeChanges(t *testing.T) {
 	)
 }
 
+func BenchmarkDrawNodeChanges(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		benchmarkDrawNodes(
+			Printable{"a": "b"},
+		)
+	}
+}
+
 func TestDrawNodeError(t *testing.T) {
 	t.Parallel()
 
@@ -137,6 +199,14 @@ func TestDrawNodeError(t *testing.T) {
 		Printable{"error": "x"},
 		"root:\n\tError: x\n\tMessages:\n\tHas Changes: yes\n\tChanges:\n\t\terror: \"\" => \"x\"\n\n",
 	)
+}
+
+func BenchmarkDrawNodeError(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		benchmarkDrawNodes(
+			Printable{"error": "x"},
+		)
+	}
 }
 
 // printable stub


### PR DESCRIPTION
Optimized human printer and added benchmarks to tests

Stats on improvements:

```
name                       old time/op    new time/op    delta
DrawNodeNoChanges             108µs ± 2%      62µs ± 8%  -42.47%        (p=0.000 n=20+19)
DrawNodeNoChangesFiltered    6.63µs ± 5%    6.55µs ±10%     ~           (p=0.091 n=19+20)
DrawNodeMetaFiltered         6.65µs ± 3%    6.42µs ± 2%   -3.49%        (p=0.000 n=19+20)
DrawNodeChanges               122µs ± 2%      59µs ± 2%  -51.69%        (p=0.000 n=18+20)
DrawNodeError                 124µs ±13%      59µs ± 1%  -52.43%        (p=0.000 n=19+20)

name                       old alloc/op   new alloc/op   delta
DrawNodeNoChanges            18.2kB ± 0%     6.2kB ± 0%  -66.09%        (p=0.000 n=20+20)
DrawNodeNoChangesFiltered    3.86kB ± 0%    3.86kB ± 0%     ~     (all samples are equal)
DrawNodeMetaFiltered         3.86kB ± 0%    3.86kB ± 0%     ~     (all samples are equal)
DrawNodeChanges              19.9kB ± 0%     6.5kB ± 0%  -67.52%        (p=0.000 n=20+20)
DrawNodeError                20.2kB ± 0%     6.5kB ± 0%  -68.03%        (p=0.000 n=20+20)

name                       old allocs/op  new allocs/op  delta
DrawNodeNoChanges               381 ± 0%       122 ± 0%  -67.98%        (p=0.000 n=20+20)
DrawNodeNoChangesFiltered      82.0 ± 0%      82.0 ± 0%     ~     (all samples are equal)
DrawNodeMetaFiltered           82.0 ± 0%      82.0 ± 0%     ~     (all samples are equal)
DrawNodeChanges                 417 ± 0%       123 ± 0%  -70.50%        (p=0.000 n=20+20)
DrawNodeError                   425 ± 0%       123 ± 0%  -71.06%        (p=0.000 n=20+20)
```
