### PR TITLE
Fix error handling when fail to print results during plan or apply

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -94,7 +94,7 @@ real happens.`,
 			// print results
 			out, perr := printer.Show(ctx, results)
 			if perr != nil {
-				log.Fatalf("[FATAL] %s: failed printing results: %s\n", fname, err)
+				log.Fatalf("[FATAL] %s: failed printing results: %s\n", fname, perr)
 			}
 
 			fmt.Print("\n")

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -77,7 +77,7 @@ can be done separately to see what needs to be changed before execution.`,
 			// print results
 			out, perr := getPrinter().Show(ctx, results)
 			if perr != nil {
-				log.Fatalf("[FATAL] %s: failed printing results: %s\n", fname, err)
+				log.Fatalf("[FATAL] %s: failed printing results: %s\n", fname, perr)
 			}
 
 			fmt.Print("\n")


### PR DESCRIPTION
Bug fix: change to output correct error if unable to print results in `plan` or `apply`
