### PR TITLE
DO NOT MERGE: Viper flags with the same name interfere

### DIFF
--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -93,5 +93,7 @@ func init() {
 	planCmd.Flags().Bool("show-meta", false, "show metadata (params and modules)")
 	planCmd.Flags().Bool("only-show-changes", false, "only show changes")
 	addParamsArguments(planCmd.PersistentFlags())
+	viperBindPFlags(planCmd.Flags())
+
 	RootCmd.AddCommand(planCmd)
 }


### PR DESCRIPTION
Before this change, the 'show-meta' and 'only-show-changes' on 'plan' did not work because the flags weren't bound to viper. After this change, 'show-meta' and 'only-show-changes' on apply always report false. Flags that are bound to viper seem to block previous flags of the same, and the 'init' function for 'plan' is called after 'apply'.
