### PR TITLE
Add param validation w/ type checks and predicates

### DIFF
--- a/render/render.go
+++ b/render/render.go
@@ -99,12 +99,8 @@ func (p pipelineGen) prepareNode(idi interface{}) monad.Monad {
 
 			// Get a resource with a fake renderer so that we can have a stub value to
 			// track the expected return type of the thunk
-			fakePrep, fakePrepErr := getTypedResourcePointer(res)
-			if fakePrepErr != nil {
-				return either.RightM(fakePrepErr)
-			}
 
-			return either.RightM(createThunk(fakePrep, func(factory *Factory) (resource.Task, error) {
+			return either.RightM(createThunk(func(factory *Factory) (resource.Task, error) {
 				dynamicRenderer, rendErr := factory.GetRenderer(p.ID)
 				if rendErr != nil {
 					return nil, rendErr
@@ -141,11 +137,11 @@ type PrepareThunk struct {
 	Thunk func(*Factory) (resource.Task, error) `hash:"ignore"`
 }
 
-func createThunk(task resource.Task, f func(*Factory) (resource.Task, error)) *PrepareThunk {
+func createThunk(f func(*Factory) (resource.Task, error)) *PrepareThunk {
 	junk := make([]byte, 32)
 	rand.Read(junk)
 	return &PrepareThunk{
-		Task:  task,
+		Task:  &resource.ThunkTask{},
 		Thunk: f,
 		Data:  junk,
 	}

--- a/resource/param/preparer.go
+++ b/resource/param/preparer.go
@@ -15,9 +15,15 @@
 package param
 
 import (
+	"bytes"
 	"errors"
+	"fmt"
+	"math"
+	"strconv"
+	"text/template"
 
 	"github.com/asteris-llc/converge/load/registry"
+	"github.com/asteris-llc/converge/render/extensions"
 	"github.com/asteris-llc/converge/resource"
 )
 
@@ -31,24 +37,139 @@ type Preparer struct {
 	// provided to this parameter. If this field is not set, this param will be
 	// treated as required.
 	Default *string `hcl:"default"`
+	Type    string  `hcl:"type"`
+	Rules   []*Rule `hcl:"rule"`
+}
+
+type Rule struct {
+	Description string   `hcl:"description"`
+	Must        []string `hcl:"must"`
+	Should      []string `hcl:"should"`
+}
+
+type ParamTest struct {
+	level    int
+	template *template.Template
+	value    interface{}
 }
 
 // Prepare a new task
 func (p *Preparer) Prepare(render resource.Renderer) (resource.Task, error) {
-	if val, present := render.Value(); present {
-		return &Param{Value: val}, nil
+	val, present := render.Value()
+
+	if !present {
+		if p.Default == nil {
+			return nil, errors.New("param is required")
+		} else {
+			def, err := render.Render("default", *p.Default)
+			if err != nil {
+				return nil, err
+			}
+
+			if _, err := strconv.Atoi(def); err == nil {
+				p.Type = "int"
+			} else {
+				p.Type = "string"
+			}
+
+			val = def
+		}
+	} else {
+		if p.Type == "" {
+			p.Type = "string"
+		}
 	}
 
-	if p.Default == nil {
-		return nil, errors.New("param is required")
-	}
-
-	def, err := render.Render("default", *p.Default)
+	var paramTests []*ParamTest
+	lang, err := ValidationLanguage(val, p.Type)
 	if err != nil {
 		return nil, err
 	}
 
-	return &Param{Value: def}, nil
+	for rNum, rule := range p.Rules {
+		pt := &ParamTest{value: val}
+		for mNum, must := range rule.Must {
+			must = "{{" + must + "}}"
+			pt.level = 1
+			name := fmt.Sprintf("rule-%d-must-%d", rNum, mNum)
+			pt.template, err = template.New(name).Funcs(lang.Funcs).Parse(must)
+			if err != nil {
+				return nil, err
+			}
+			paramTests = append(paramTests, pt)
+		}
+		for sNum, should := range rule.Should {
+			should = "{{" + should + "}}"
+			pt.level = 2
+			name := fmt.Sprintf("rule-%d-should-%d", rNum, sNum)
+			pt.template, err = template.New(name).Funcs(lang.Funcs).Parse(should)
+			if err != nil {
+				return nil, err
+			}
+			paramTests = append(paramTests, pt)
+		}
+	}
+
+	for _, pt := range paramTests {
+		if err = pt.Validate(); err != nil {
+			return nil, err
+		}
+	}
+
+	return &Param{Value: val}, nil
+}
+
+func (pt *ParamTest) Validate() error {
+	var buffer bytes.Buffer
+	if err := pt.template.Execute(&buffer, pt.value); err != nil {
+		return err
+	}
+
+	if pass := buffer.String(); pass != "true" {
+		return fmt.Errorf("Expected true from %s, got %s", pt.template.Name(), pass)
+	}
+
+	return nil
+}
+
+func ValidationLanguage(val, vtype string) (*extensions.LanguageExtension, error) {
+	lang := extensions.DefaultLanguage()
+
+	switch vtype {
+	case "int":
+		num, err := strconv.Atoi(val)
+		if err != nil {
+			return lang, fmt.Errorf("vtype is \"int\", but converting \"%s\" failed", val)
+		}
+		lang.On("min", func(min int) bool { return num >= min })
+		lang.On("max", func(max int) bool { return num <= max })
+		lang.On("range", func(min, max int) bool { return min <= num && num <= max })
+		lang.On("isEven", func() bool { return math.Mod(float64(num), 2) == 0 })
+		lang.On("isOdd", func() bool { return math.Mod(float64(num), 2) != 0 })
+	case "string":
+		lang.On("empty", func() bool { return len(val) == 0 })
+		lang.On("oneOf", func(list ...string) bool {
+			isOneOf := false
+			for _, item := range list {
+				if val == item {
+					isOneOf = true
+				}
+			}
+			return isOneOf
+		})
+		lang.On("notIn", func(list ...string) bool {
+			for _, item := range list {
+				if val == item {
+					return false
+				}
+			}
+			return true
+		})
+	default:
+		return lang, fmt.Errorf("Unhandled case %T for %v", vtype, val)
+	}
+
+	return lang, nil
 }
 
 func init() {

--- a/resource/param/preparer.go
+++ b/resource/param/preparer.go
@@ -35,8 +35,8 @@ const (
 )
 
 const (
-	ValidatePass int = 0
-	ValidateFail int = 2
+	ValidatePass int = iota
+	ValidateFail
 )
 
 // Rule for Type Validation
@@ -154,6 +154,7 @@ func ValidateType(value interface{}, predicates map[string]string) error {
 		str := value.(string)
 
 		funcMap = template.FuncMap{
+			"length":   func() int { return len(str) },
 			"empty":    func() bool { return len(str) == 0 },
 			"notEmpty": func() bool { return len(str) != 0 },
 			"oneOf": func(list string) bool {
@@ -181,14 +182,15 @@ func ValidateType(value interface{}, predicates map[string]string) error {
 			return err
 		}
 
-		returnCode, err := strconv.Atoi(buffer.String())
+		failed, err := strconv.ParseBool(buffer.String())
 		if err != nil {
 			return err
 		}
 
-		if returnCode != 0 {
-			log.Debug(fmt.Sprintf("%s", predicate))
-			return fmt.Errorf("%s: expected %d, got %d", tmpl.Name(), ValidatePass, returnCode)
+		if failed {
+			err = fmt.Errorf("%s: expected %d, got %d", tmpl.Name(), ValidatePass, ValidateFail)
+			log.WithField("predicate", predicate).Debug(err.Error())
+			return err
 		}
 	}
 	return nil

--- a/resource/param/preparer_test.go
+++ b/resource/param/preparer_test.go
@@ -74,6 +74,7 @@ func TestPreparerRequired(t *testing.T) {
 func TestTable_PreparerValidate(t *testing.T) {
 	t.Parallel()
 
+	err := errors.New("pred#0: expected 0, got 1")
 	test_table := []struct {
 		paramType param.ParamType
 		expected  error
@@ -85,21 +86,21 @@ func TestTable_PreparerValidate(t *testing.T) {
 		// type check only
 		{param.ParamTypeString, nil, "password", nil},
 
-		// rule checking with only default text/template funcs
-		{param.ParamTypeString, nil, "password", []string{"len . | le 4"}},
-		{param.ParamTypeString, errors.New("pred#0: expected 0, got 2"), "password", []string{"len . | ge 4"}},
+		// length func
+		{param.ParamTypeString, nil, "password", []string{"le 4 length"}},
+		{param.ParamTypeString, err, "password", []string{"ge 4 length"}},
 
-		// rule checking for empty func
+		// empty func
 		{param.ParamTypeString, nil, "", []string{"empty"}},
-		{param.ParamTypeString, errors.New("pred#0: expected 0, got 2"), "password", []string{"empty"}},
+		{param.ParamTypeString, err, "password", []string{"empty"}},
 
-		// rule checking for oneOf func
+		// oneOf func
 		{param.ParamTypeString, nil, "password", []string{"oneOf `password`"}},
-		{param.ParamTypeString, errors.New("pred#0: expected 0, got 2"), "password", []string{"oneOf `correthorsebatterystaple`"}},
+		{param.ParamTypeString, err, "password", []string{"oneOf `correthorsebatterystaple`"}},
 
-		// rule checking for notOneOf func
+		// notOneOf func
 		{param.ParamTypeString, nil, "correcthorsebatterystaple", []string{"notOneOf `password hunter2`"}},
-		{param.ParamTypeString, errors.New("pred#0: expected 0, got 2"), "password", []string{"notOneOf `password hunter2`"}},
+		{param.ParamTypeString, err, "password", []string{"notOneOf `password hunter2`"}},
 
 		// ParamTypeInt checks, with pass/fail pairs
 
@@ -107,15 +108,16 @@ func TestTable_PreparerValidate(t *testing.T) {
 		{param.ParamTypeInt, nil, "12", nil},
 		{param.ParamTypeInt, errors.New(`paramType is "int", but converting "twelve" failed`), "twelve", nil},
 
-		// rule checking for min func
+		// min func
 		{param.ParamTypeInt, nil, "12", []string{"min 3"}},
-		{param.ParamTypeInt, errors.New("pred#0: expected 0, got 2"), "12", []string{"min 48"}},
+		{param.ParamTypeInt, err, "12", []string{"min 48"}},
 
-		// rule checking for max func
+		// max func
 		{param.ParamTypeInt, nil, "12", []string{"max 48"}},
-		{param.ParamTypeInt, errors.New("pred#0: expected 0, got 2"), "12", []string{"max 3"}},
+		{param.ParamTypeInt, err, "12", []string{"max 3"}},
 
 		// ParamTypeInferred checks
+
 		{param.ParamTypeInferred, nil, "hello", nil},
 		{param.ParamTypeInferred, nil, "123", nil},
 	}

--- a/resource/param/preparer_test.go
+++ b/resource/param/preparer_test.go
@@ -71,41 +71,43 @@ func TestPreparerRequired(t *testing.T) {
 	}
 }
 
-func TestPreparerValidate(t *testing.T) {
+func TestTable_PreparerValidate(t *testing.T) {
 	t.Parallel()
 
 	test_table := []struct {
-		pType string
-		exp   error
-		val   string
-		musts []string
+		paramType string
+		expected  error
+		value     string
+		musts     []string
 	}{
-		// STRING TESTS
-
-		// type check only
 		{"string", nil, "password", nil},
 
-		// rule checks
 		{"string", nil, "password", []string{"len . | le 4"}},
-		{"string", errors.New("Expected true from rule-0-must-0, got false"), "password", []string{"empty"}},
 
-		// INT TESTS
+		{"string", nil, "", []string{"empty"}},
+		{"string", errors.New("pred#0: expected 0, got 2"), "password", []string{"empty"}},
 
-		// type check only
+		{"string", nil, "password", []string{`oneOf "password"`}},
+		{"string", errors.New("pred#0: expected 0, got 2"), "password", []string{`oneOf "correthorsebatterystaple"`}},
+
+		{"string", nil, "correcthorsebatterystaple", []string{`notOneOf "password" "hunter2"`}},
+		{"string", errors.New("pred#0: expected 0, got 2"), "password", []string{`notOneOf "password" "hunter2"`}},
+
 		{"int", nil, "12", nil},
-		{"int", errors.New("vtype is \"int\", but converting \"twelve\" failed"), "twelve", nil},
+		{"int", errors.New("paramType is \"int\", but converting \"twelve\" failed"), "twelve", nil},
 
-		// rule checks
 		{"int", nil, "12", []string{"min 3"}},
-		{"int", errors.New("Expected true from rule-0-must-0, got false"), "12", []string{"max 3"}},
+		{"int", errors.New("pred#0: expected 0, got 2"), "12", []string{"max 3"}},
+
+		{"", nil, "hello", nil},
+		{"", nil, "123", nil},
 	}
 
-	for _, test := range test_table {
-		rules := &param.Rule{Must: test.musts}
-		prep := &param.Preparer{Type: test.pType, Rules: []*param.Rule{rules}}
+	for index, test := range test_table {
+		prep := &param.Preparer{Type: test.paramType, Must: test.musts}
 
-		_, act := prep.Prepare(fakerenderer.NewWithValue(test.val))
-		assert.Equal(t, test.exp, act)
+		_, actual := prep.Prepare(fakerenderer.NewWithValue(test.value))
+		assert.Equal(t, test.expected, actual, fmt.Sprintf("Test #%d failed\n", index))
 	}
 }
 

--- a/resource/thunktask.go
+++ b/resource/thunktask.go
@@ -19,8 +19,7 @@ import "fmt"
 // ThunkTask represents an abstract task over a thunk, used when we need to
 // serialized a thunked value.
 type ThunkTask struct {
-	Name        string
-	ThunkedType Task
+	Name string
 }
 
 // Check returns a task status with thunk information
@@ -42,9 +41,8 @@ func (t *ThunkTask) ToStatus() *Status {
 }
 
 // NewThunkedTask generates a ThunkTask from a PrepareThunk
-func NewThunkedTask(name string, thunkedType Task) *ThunkTask {
+func NewThunkedTask(name string) *ThunkTask {
 	return &ThunkTask{
-		ThunkedType: thunkedType,
-		Name:        name,
+		Name: name,
 	}
 }

--- a/rpc/grapher.go
+++ b/rpc/grapher.go
@@ -95,7 +95,7 @@ func (g *grapher) Graph(in *pb.LoadRequest, stream pb.Grapher_GraphServer) error
 func resolveVertex(id string, vertex interface{}) (resource.Task, error) {
 	switch v := vertex.(type) {
 	case *render.PrepareThunk:
-		return resource.NewThunkedTask(id, v.Task), nil
+		return resource.NewThunkedTask(id), nil
 	case *resource.TaskWrapper:
 		if resolved, ok := resource.ResolveTask(v); ok {
 			return resolved, nil

--- a/samples/errors/bad_params.hcl
+++ b/samples/errors/bad_params.hcl
@@ -1,9 +1,6 @@
 param "bad" {
-  type = "int"
   default = 5
   rule {
-    must = [
-    	"max 4",
-	]
+    must = "max 4"
   }
 }

--- a/samples/errors/bad_params.hcl
+++ b/samples/errors/bad_params.hcl
@@ -1,6 +1,4 @@
 param "bad" {
   default = 5
-  rule {
-    must = "max 4"
-  }
+  must = "max 4"
 }

--- a/samples/errors/bad_params.hcl
+++ b/samples/errors/bad_params.hcl
@@ -1,4 +1,0 @@
-param "bad" {
-  default = 5
-  must = ["max 4"]
-}

--- a/samples/errors/bad_params.hcl
+++ b/samples/errors/bad_params.hcl
@@ -1,4 +1,4 @@
 param "bad" {
   default = 5
-  must = "max 4"
+  must = ["max 4"]
 }

--- a/samples/errors/bad_params.hcl
+++ b/samples/errors/bad_params.hcl
@@ -1,0 +1,9 @@
+param "bad" {
+  type = "int"
+  default = 5
+  rule {
+    must = [
+    	"max 4",
+	]
+  }
+}

--- a/samples/paramValidation.hcl
+++ b/samples/paramValidation.hcl
@@ -27,12 +27,12 @@ param "blocksize" {
 
 task.query "sayconverge" {
   interpreter = "/bin/bash"
-  query = "echo -n converge"
+  query       = "echo -n converge"
 }
 
 param "converge" {
   default = "{{lookup `task.query.sayconverge.checkstatus.stdout`}}"
-  must = ["oneOf `converge`"]
+  must    = ["oneOf `converge`"]
 }
 
 param "cipher" {

--- a/samples/paramValidation.hcl
+++ b/samples/paramValidation.hcl
@@ -1,4 +1,7 @@
-### Good HCL Examples
+/*
+These are examples of how you can validate your parameters. This includes a simple type checking system, and user-defined constraints.
+The constraints are evaulated as text/template fragments, with a small set of funcs included.
+*/
 
 param "name" {
   default = "converge"
@@ -24,5 +27,5 @@ param "blocksize" {
 
 param "cipher" {
   default = "Twofish"
-  must    = ["oneOf \"Rijndael\" \"Serpent\" \"Twofish\"", "notOneOf \"DES\" \"Blowfish\""]
+  must    = ["oneOf `Rijndael Serpent Twofish`", "notOneOf `DES Blowfish`"]
 }

--- a/samples/paramValidation.hcl
+++ b/samples/paramValidation.hcl
@@ -1,15 +1,18 @@
 ### Good HCL Examples
 
-param "name" {}
+param "name" {
+  default = "converge"
+}
 
 param "password" {
   # type defaults to string
-  must = ["len . | lt 5", "len . | gt 25"]
+  default = "password"
+  must    = ["len . | lt 5", "len . | gt 25"]
 }
 
 param "quorum" {
-  type = "int"
-  must = ["isOdd", "min 1"]
+  default = 3
+  must    = ["isOdd", "min 1"]
 }
 
 param "blocksize" {
@@ -19,7 +22,7 @@ param "blocksize" {
   must = ["min 50", "max 512"]
 }
 
-
 param "cipher" {
-  must = ["oneOf \"Rijndael\" \"Serpent\" \"Twofish\"", "notOneOf \"DES\" \"Blowfish\""]
+  default = "Twofish"
+  must    = ["oneOf \"Rijndael\" \"Serpent\" \"Twofish\"", "notOneOf \"DES\" \"Blowfish\""]
 }

--- a/samples/paramValidation.hcl
+++ b/samples/paramValidation.hcl
@@ -1,0 +1,25 @@
+### Good HCL Examples
+
+param "name" {}
+
+param "password" {
+  # type defaults to string
+  must = ["len . | lt 5", "len . | gt 25"]
+}
+
+param "quorum" {
+  type = "int"
+  must = ["isOdd", "min 1"]
+}
+
+param "blocksize" {
+  default = 128
+
+  # type is inferred from default
+  must = ["min 50", "max 512"]
+}
+
+
+param "cipher" {
+  must = ["oneOf \"Rijndael\" \"Serpent\" \"Twofish\"", "notOneOf \"DES\" \"Blowfish\""]
+}

--- a/samples/paramValidation.hcl
+++ b/samples/paramValidation.hcl
@@ -25,6 +25,16 @@ param "blocksize" {
   must = ["min 50", "max 512"]
 }
 
+task.query "sayconverge" {
+  interpreter = "/bin/bash"
+  query = "echo -n converge"
+}
+
+param "converge" {
+  default = "{{lookup `task.query.sayconverge.checkstatus.stdout`}}"
+  must = ["oneOf `converge`"]
+}
+
 param "cipher" {
   default = "Twofish"
   must    = ["oneOf `Rijndael Serpent Twofish`", "notOneOf `DES Blowfish`"]


### PR DESCRIPTION
This feature adds the ability for users to constrain their inputs into a
converge system. The specification that this is based on is located in
the [wiki](https://github.com/asteris-llc/converge/wiki/Parameter-Types-and-Validation).

Things that work:

- you can specify an `int` as a value, and the validation loads in the
  DSL for checking the values, as specified

  The functions that are loaded into the templates are actually closures
  containing the value of the param with proper type during the Prepare
  stage, so we don't need to pipe in that value later on. This changes
  how the rules are wrapped within the validation logic, so this strays
  from the spec, but I think this will work better, and give the users
  more flexibility with rules that they write. The spec will need to be
  updated if everyone agrees.
- There is a table test that I wrote for this that works pretty well,
  and it should be easier to backfill with more test cases as we come up
  with more corner cases and types
- other tests that I didn't touch still passed (woo!)

Things that don't work yet:

- I did not make a specialized version of `len` for string types. We can
  include `len` from `text/template`. Because of the validator closures
  (as mentioned above), users can use `len . |` in their rules, which
  matches how golang devs operate with `text/template` anyhow. If the
  spec needs to be changed, it'll need to include documentation for the
  difference between the validator closures and the normal funcs
- the `description` field in a rule is not checked for, and is not
  included as a field in the struct. I forgot if that feature was going
  to be part of our "metadata for nodes" feature. Plus, I feel like it
  is a lower priority item for the demo, so I want to push it to last if
  need be
- loading a parameter with a rule stanza causes an error. I'll need to
  pair with someone to help work out what I'm doing wrong

TODOs:

- Backfill more test cases
- Add sample .hcl files to appropriate places