### PR TITLE
Use `MakeLanguage` for dependecy resolution to ensure that no

### DIFF
--- a/load/dependencyresolver.go
+++ b/load/dependencyresolver.go
@@ -92,7 +92,7 @@ func getParams(node *parse.Node) (out []string, err error) {
 	}
 
 	type stub struct{}
-	language := extensions.MakeLanguage()
+	language := extensions.MinimalLanguage()
 	language.On("param", extensions.RememberCalls(&out, 0))
 	for _, s := range strings {
 		useless := stub{}
@@ -116,7 +116,7 @@ func getXrefs(g *graph.Graph, node *parse.Node) (out []string, err error) {
 	if err != nil {
 		return nil, err
 	}
-	language := extensions.MakeLanguage()
+	language := extensions.MinimalLanguage()
 	language.On(extensions.RefFuncName, extensions.RememberCalls(&calls, 0))
 	for _, s := range strings {
 		tmpl, tmplErr := template.New("DependencyTemplate").Funcs(language.Funcs).Parse(s)

--- a/load/dependencyresolver.go
+++ b/load/dependencyresolver.go
@@ -92,7 +92,7 @@ func getParams(node *parse.Node) (out []string, err error) {
 	}
 
 	type stub struct{}
-	language := extensions.DefaultLanguage()
+	language := extensions.MakeLanguage()
 	language.On("param", extensions.RememberCalls(&out, 0))
 	for _, s := range strings {
 		useless := stub{}
@@ -116,7 +116,7 @@ func getXrefs(g *graph.Graph, node *parse.Node) (out []string, err error) {
 	if err != nil {
 		return nil, err
 	}
-	language := extensions.DefaultLanguage()
+	language := extensions.MakeLanguage()
 	language.On(extensions.RefFuncName, extensions.RememberCalls(&calls, 0))
 	for _, s := range strings {
 		tmpl, tmplErr := template.New("DependencyTemplate").Funcs(language.Funcs).Parse(s)

--- a/render/extensions/extensions.go
+++ b/render/extensions/extensions.go
@@ -80,7 +80,7 @@ func MinimalLanguage() *LanguageExtension {
 
 // DefaultLanguage provides a default language extension.  It creates default
 // implementations of context-free and non-dependency-generating functions
-// (e.g. split) and provides a unimplemented function for functions that must bes
+// (e.g. split) and provides a unimplemented function for functions that must be
 // supplied with context or which may register dependencies.
 func DefaultLanguage() *LanguageExtension {
 	language := MakeLanguage()
@@ -172,6 +172,11 @@ func StubTemplateFunc(...string) (string, error) {
 	return "", nil
 }
 
+// newStub generates a stub function that always returns returnVal when called,
+// and supports a variadic number of arguments.  It is used to generate stubs
+// that need to return a specific value or real data type (e.g. stubs for
+// `platform` which must return a valid `*platform.Platform` to prevent template
+// execution errors).
 func newStub(returnVal interface{}) func(...string) (interface{}, error) {
 	return func(...string) (interface{}, error) {
 		return returnVal, nil


### PR DESCRIPTION
unimplemented calls result in early template execution termination.

Fixes issue #254