### PR TITLE
Simplify Status implementation

### DIFF
--- a/apply/apply_test.go
+++ b/apply/apply_test.go
@@ -33,7 +33,7 @@ func TestApplyNoOp(t *testing.T) {
 
 	g := graph.New()
 	task := faketask.Swapper()
-	g.Add("root", &plan.Result{Status: &resource.Status{WillChange: true}, Task: task})
+	g.Add("root", &plan.Result{Status: &resource.Status{WarningLevel: resource.StatusWillChange}, Task: task})
 
 	require.NoError(t, g.Validate())
 
@@ -51,7 +51,7 @@ func TestApplyNoRun(t *testing.T) {
 
 	g := graph.New()
 	task := faketask.NoOp()
-	g.Add("root", &plan.Result{Status: &resource.Status{WillChange: false}, Task: task})
+	g.Add("root", &plan.Result{Status: &resource.Status{WarningLevel: resource.StatusWontChange}, Task: task})
 
 	require.NoError(t, g.Validate())
 
@@ -67,8 +67,8 @@ func TestApplyErrorsBelow(t *testing.T) {
 	defer logging.HideLogs(t)()
 
 	g := graph.New()
-	g.Add("root", &plan.Result{Status: &resource.Status{WillChange: true}, Task: faketask.NoOp()})
-	g.Add("root/err", &plan.Result{Status: &resource.Status{WillChange: true}, Task: faketask.Error()})
+	g.Add("root", &plan.Result{Status: &resource.Status{WarningLevel: resource.StatusWillChange}, Task: faketask.NoOp()})
+	g.Add("root/err", &plan.Result{Status: &resource.Status{WarningLevel: resource.StatusWillChange}, Task: faketask.Error()})
 
 	g.ConnectParent("root", "root/err")
 
@@ -93,7 +93,7 @@ func TestApplyStillChange(t *testing.T) {
 	defer logging.HideLogs(t)()
 
 	g := graph.New()
-	g.Add("root", &plan.Result{Status: &resource.Status{WillChange: true}, Task: faketask.WillChange()})
+	g.Add("root", &plan.Result{Status: &resource.Status{WarningLevel: resource.StatusWillChange}, Task: faketask.WillChange()})
 
 	require.NoError(t, g.Validate())
 

--- a/apply/apply_test.go
+++ b/apply/apply_test.go
@@ -33,7 +33,7 @@ func TestApplyNoOp(t *testing.T) {
 
 	g := graph.New()
 	task := faketask.Swapper()
-	g.Add("root", &plan.Result{Status: &resource.Status{WarningLevel: resource.StatusWillChange}, Task: task})
+	g.Add("root", &plan.Result{Status: &resource.Status{Level: resource.StatusWillChange}, Task: task})
 
 	require.NoError(t, g.Validate())
 
@@ -51,7 +51,7 @@ func TestApplyNoRun(t *testing.T) {
 
 	g := graph.New()
 	task := faketask.NoOp()
-	g.Add("root", &plan.Result{Status: &resource.Status{WarningLevel: resource.StatusWontChange}, Task: task})
+	g.Add("root", &plan.Result{Status: &resource.Status{Level: resource.StatusWontChange}, Task: task})
 
 	require.NoError(t, g.Validate())
 
@@ -67,8 +67,8 @@ func TestApplyErrorsBelow(t *testing.T) {
 	defer logging.HideLogs(t)()
 
 	g := graph.New()
-	g.Add("root", &plan.Result{Status: &resource.Status{WarningLevel: resource.StatusWillChange}, Task: faketask.NoOp()})
-	g.Add("root/err", &plan.Result{Status: &resource.Status{WarningLevel: resource.StatusWillChange}, Task: faketask.Error()})
+	g.Add("root", &plan.Result{Status: &resource.Status{Level: resource.StatusWillChange}, Task: faketask.NoOp()})
+	g.Add("root/err", &plan.Result{Status: &resource.Status{Level: resource.StatusWillChange}, Task: faketask.Error()})
 
 	g.ConnectParent("root", "root/err")
 
@@ -93,7 +93,7 @@ func TestApplyStillChange(t *testing.T) {
 	defer logging.HideLogs(t)()
 
 	g := graph.New()
-	g.Add("root", &plan.Result{Status: &resource.Status{WarningLevel: resource.StatusWillChange}, Task: faketask.WillChange()})
+	g.Add("root", &plan.Result{Status: &resource.Status{Level: resource.StatusWillChange}, Task: faketask.WillChange()})
 
 	require.NoError(t, g.Validate())
 

--- a/apply/pipeline.go
+++ b/apply/pipeline.go
@@ -120,11 +120,7 @@ func (g *pipelineGen) applyNode(taski interface{}) monad.Monad {
 	if !ok {
 		return either.LeftM(fmt.Errorf("apply expected a resultWrappert but got %T", val))
 	}
-	renderer, err := g.Renderer(g.ID)
-	if err != nil {
-		return either.LeftM(fmt.Errorf("unable to get renderer for %s", g.ID))
-	}
-	applyStatus, err := twrapper.Plan.Task.Apply(renderer)
+	applyStatus, err := twrapper.Plan.Task.Apply()
 	if err != nil {
 		err = fmt.Errorf("error applying %s: %s", g.ID, err)
 	}

--- a/apply/pipeline.go
+++ b/apply/pipeline.go
@@ -76,7 +76,7 @@ func (g *pipelineGen) DependencyCheck(taskI interface{}) monad.Monad {
 		if err := dep.Error(); err != nil {
 			errResult := &Result{
 				Ran:    false,
-				Status: &resource.Status{WillChange: true},
+				Status: &resource.Status{WarningLevel: resource.StatusWillChange},
 				Err:    fmt.Errorf("error in dependency %q", depID),
 			}
 			return either.RightM(either.LeftM(errResult))

--- a/apply/pipeline.go
+++ b/apply/pipeline.go
@@ -76,7 +76,7 @@ func (g *pipelineGen) DependencyCheck(taskI interface{}) monad.Monad {
 		if err := dep.Error(); err != nil {
 			errResult := &Result{
 				Ran:    false,
-				Status: &resource.Status{WarningLevel: resource.StatusWillChange},
+				Status: &resource.Status{Level: resource.StatusWillChange},
 				Err:    fmt.Errorf("error in dependency %q", depID),
 			}
 			return either.RightM(either.LeftM(errResult))

--- a/helpers/faketask/faketask.go
+++ b/helpers/faketask/faketask.go
@@ -22,27 +22,27 @@ import (
 
 // FakeTask for testing things that require real tasks
 type FakeTask struct {
-	Status     string
-	WillChange bool
-	Error      error
+	Status string
+	Level  resource.StatusLevel
+	Error  error
 }
 
 // Check returns values set on struct
 func (ft *FakeTask) Check(resource.Renderer) (resource.TaskStatus, error) {
-	return &resource.Status{Output: []string{ft.Status}, WillChange: ft.WillChange}, ft.Error
+	return &resource.Status{Output: []string{ft.Status}, WarningLevel: ft.Level}, ft.Error
 }
 
 // Apply returns values set on struct
 func (ft *FakeTask) Apply() (resource.TaskStatus, error) {
-	return &resource.Status{Output: []string{ft.Status}, WillChange: ft.WillChange}, ft.Error
+	return &resource.Status{Output: []string{ft.Status}, WarningLevel: ft.Level}, ft.Error
 }
 
 // NoOp returns a FakeTask that doesn't have to do anything
 func NoOp() *FakeTask {
 	return &FakeTask{
-		Status:     "all good",
-		WillChange: false,
-		Error:      nil,
+		Status: "all good",
+		Level:  resource.StatusWontChange,
+		Error:  nil,
 	}
 }
 
@@ -50,18 +50,18 @@ func NoOp() *FakeTask {
 // applying
 func Error() *FakeTask {
 	return &FakeTask{
-		Status:     "error",
-		WillChange: false,
-		Error:      errors.New("error"),
+		Status: "error",
+		Level:  resource.StatusFatal,
+		Error:  errors.New("error"),
 	}
 }
 
 // WillChange returns a FakeTask that will always change
 func WillChange() *FakeTask {
 	return &FakeTask{
-		Status:     "changed",
-		WillChange: true,
-		Error:      nil,
+		Status: "changed",
+		Level:  resource.StatusWillChange,
+		Error:  nil,
 	}
 }
 
@@ -75,14 +75,22 @@ type FakeSwapper struct {
 
 // Check returns values set on struct
 func (ft *FakeSwapper) Check(resource.Renderer) (resource.TaskStatus, error) {
-	return &resource.Status{Output: []string{ft.Status}, WillChange: ft.WillChange}, ft.Error
+	return &resource.Status{Output: []string{ft.Status}, WarningLevel: ft.level()}, ft.Error
 }
 
 // Apply negates the current WillChange value set on struct and returns
 // configured error
 func (ft *FakeSwapper) Apply() (resource.TaskStatus, error) {
 	ft.WillChange = !ft.WillChange
-	return &resource.Status{Output: []string{ft.Status}, WillChange: ft.WillChange}, ft.Error
+	return &resource.Status{Output: []string{ft.Status}, WarningLevel: ft.level()}, ft.Error
+}
+
+func (ft *FakeSwapper) level() resource.StatusLevel {
+	if ft.WillChange {
+		return resource.StatusWillChange
+	}
+
+	return resource.StatusNoChange
 }
 
 // Swapper creates a new stub swapper with an initial WillChange value of true

--- a/helpers/faketask/faketask.go
+++ b/helpers/faketask/faketask.go
@@ -29,12 +29,12 @@ type FakeTask struct {
 
 // Check returns values set on struct
 func (ft *FakeTask) Check(resource.Renderer) (resource.TaskStatus, error) {
-	return &resource.Status{Output: []string{ft.Status}, WarningLevel: ft.Level}, ft.Error
+	return &resource.Status{Output: []string{ft.Status}, Level: ft.Level}, ft.Error
 }
 
 // Apply returns values set on struct
 func (ft *FakeTask) Apply() (resource.TaskStatus, error) {
-	return &resource.Status{Output: []string{ft.Status}, WarningLevel: ft.Level}, ft.Error
+	return &resource.Status{Output: []string{ft.Status}, Level: ft.Level}, ft.Error
 }
 
 // NoOp returns a FakeTask that doesn't have to do anything
@@ -75,14 +75,14 @@ type FakeSwapper struct {
 
 // Check returns values set on struct
 func (ft *FakeSwapper) Check(resource.Renderer) (resource.TaskStatus, error) {
-	return &resource.Status{Output: []string{ft.Status}, WarningLevel: ft.level()}, ft.Error
+	return &resource.Status{Output: []string{ft.Status}, Level: ft.level()}, ft.Error
 }
 
 // Apply negates the current WillChange value set on struct and returns
 // configured error
 func (ft *FakeSwapper) Apply() (resource.TaskStatus, error) {
 	ft.WillChange = !ft.WillChange
-	return &resource.Status{Output: []string{ft.Status}, WarningLevel: ft.level()}, ft.Error
+	return &resource.Status{Output: []string{ft.Status}, Level: ft.level()}, ft.Error
 }
 
 func (ft *FakeSwapper) level() resource.StatusLevel {

--- a/helpers/faketask/faketask.go
+++ b/helpers/faketask/faketask.go
@@ -29,12 +29,12 @@ type FakeTask struct {
 
 // Check returns values set on struct
 func (ft *FakeTask) Check(resource.Renderer) (resource.TaskStatus, error) {
-	return &resource.Status{Output: []string{ft.Status}, Status: ft.Status, WillChange: ft.WillChange}, ft.Error
+	return &resource.Status{Output: []string{ft.Status}, WillChange: ft.WillChange}, ft.Error
 }
 
 // Apply returns values set on struct
 func (ft *FakeTask) Apply() (resource.TaskStatus, error) {
-	return &resource.Status{Output: []string{ft.Status}, Status: ft.Status, WillChange: ft.WillChange}, ft.Error
+	return &resource.Status{Output: []string{ft.Status}, WillChange: ft.WillChange}, ft.Error
 }
 
 // NoOp returns a FakeTask that doesn't have to do anything
@@ -75,14 +75,14 @@ type FakeSwapper struct {
 
 // Check returns values set on struct
 func (ft *FakeSwapper) Check(resource.Renderer) (resource.TaskStatus, error) {
-	return &resource.Status{Output: []string{ft.Status}, Status: ft.Status, WillChange: ft.WillChange}, ft.Error
+	return &resource.Status{Output: []string{ft.Status}, WillChange: ft.WillChange}, ft.Error
 }
 
 // Apply negates the current WillChange value set on struct and returns
 // configured error
 func (ft *FakeSwapper) Apply() (resource.TaskStatus, error) {
 	ft.WillChange = !ft.WillChange
-	return &resource.Status{Output: []string{ft.Status}, Status: ft.Status, WillChange: ft.WillChange}, ft.Error
+	return &resource.Status{Output: []string{ft.Status}, WillChange: ft.WillChange}, ft.Error
 }
 
 // Swapper creates a new stub swapper with an initial WillChange value of true

--- a/helpers/faketask/faketask.go
+++ b/helpers/faketask/faketask.go
@@ -33,8 +33,8 @@ func (ft *FakeTask) Check(resource.Renderer) (resource.TaskStatus, error) {
 }
 
 // Apply returns values set on struct
-func (ft *FakeTask) Apply(r resource.Renderer) (resource.TaskStatus, error) {
-	return ft.Check(r)
+func (ft *FakeTask) Apply() (resource.TaskStatus, error) {
+	return &resource.Status{Output: []string{ft.Status}, Status: ft.Status, WillChange: ft.WillChange}, ft.Error
 }
 
 // NoOp returns a FakeTask that doesn't have to do anything
@@ -80,9 +80,9 @@ func (ft *FakeSwapper) Check(resource.Renderer) (resource.TaskStatus, error) {
 
 // Apply negates the current WillChange value set on struct and returns
 // configured error
-func (ft *FakeSwapper) Apply(r resource.Renderer) (resource.TaskStatus, error) {
+func (ft *FakeSwapper) Apply() (resource.TaskStatus, error) {
 	ft.WillChange = !ft.WillChange
-	return ft.Check(r)
+	return &resource.Status{Output: []string{ft.Status}, Status: ft.Status, WillChange: ft.WillChange}, ft.Error
 }
 
 // Swapper creates a new stub swapper with an initial WillChange value of true

--- a/plan/pipeline.go
+++ b/plan/pipeline.go
@@ -80,7 +80,7 @@ func (g *pipelineGen) DependencyCheck(taskI interface{}) monad.Monad {
 		}
 		if err := dep.Error(); err != nil {
 			errResult := &Result{
-				Status: &resource.Status{WarningLevel: resource.StatusWillChange},
+				Status: &resource.Status{Level: resource.StatusWillChange},
 				Task:   task.Task,
 				Err:    fmt.Errorf("error in dependency %q", depID),
 			}

--- a/plan/pipeline.go
+++ b/plan/pipeline.go
@@ -80,7 +80,7 @@ func (g *pipelineGen) DependencyCheck(taskI interface{}) monad.Monad {
 		}
 		if err := dep.Error(); err != nil {
 			errResult := &Result{
-				Status: &resource.Status{WillChange: true},
+				Status: &resource.Status{WarningLevel: resource.StatusWillChange},
 				Task:   task.Task,
 				Err:    fmt.Errorf("error in dependency %q", depID),
 			}

--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -41,7 +41,7 @@ func TestPlanNoOp(t *testing.T) {
 
 	result := getResult(t, planned, "root")
 	assert.Equal(t, task.Status, result.Status.Messages()[0])
-	assert.Equal(t, task.WillChange, result.Status.HasChanges())
+	assert.False(t, result.Status.HasChanges())
 	assert.Equal(t, task, result.Task)
 }
 

--- a/prettyprinters/graphviz/providers/rpc.go
+++ b/prettyprinters/graphviz/providers/rpc.go
@@ -89,7 +89,7 @@ func (p RPCProvider) VertexGetLabel(e graphviz.GraphEntity) (pp.VisibleRenderabl
 		}
 
 		return pp.RenderableString(
-			fmt.Sprintf("%s: %s", name, dest.Value),
+			fmt.Sprintf("%s: %s", name, dest.Val),
 			p.ShowParams,
 		), nil
 

--- a/resource/docker/container/container.go
+++ b/resource/docker/container/container.go
@@ -60,8 +60,6 @@ type Container struct {
 
 // Check that a docker container with the specified configuration exists
 func (c *Container) Check(resource.Renderer) (resource.TaskStatus, error) {
-	c.Status.Status = c.Name
-
 	container, err := c.client.FindContainer(c.Name)
 	if err != nil {
 		c.Status.WarningLevel = resource.StatusFatal

--- a/resource/docker/container/container.go
+++ b/resource/docker/container/container.go
@@ -84,7 +84,7 @@ func (c *Container) Check(resource.Renderer) (resource.TaskStatus, error) {
 }
 
 // Apply starts a docker container with the specified configuration
-func (c *Container) Apply(r resource.Renderer) (resource.TaskStatus, error) {
+func (c *Container) Apply() (resource.TaskStatus, error) {
 	volumes, binds := volumeConfigs(c.Volumes)
 	config := &dc.Config{
 		Image:        c.Image,

--- a/resource/docker/container/container.go
+++ b/resource/docker/container/container.go
@@ -76,7 +76,6 @@ func (c *Container) Check(resource.Renderer) (resource.TaskStatus, error) {
 	}
 
 	if resource.AnyChanges(c.Status.Differences) {
-		c.Status.WillChange = true
 		c.Status.WarningLevel = resource.StatusWillChange
 	}
 

--- a/resource/docker/container/container.go
+++ b/resource/docker/container/container.go
@@ -62,7 +62,7 @@ type Container struct {
 func (c *Container) Check(resource.Renderer) (resource.TaskStatus, error) {
 	container, err := c.client.FindContainer(c.Name)
 	if err != nil {
-		c.Status.WarningLevel = resource.StatusFatal
+		c.Status.Level = resource.StatusFatal
 		return c, err
 	}
 
@@ -76,7 +76,7 @@ func (c *Container) Check(resource.Renderer) (resource.TaskStatus, error) {
 	}
 
 	if resource.AnyChanges(c.Status.Differences) {
-		c.Status.WarningLevel = resource.StatusWillChange
+		c.Status.Level = resource.StatusWillChange
 	}
 
 	return c, nil
@@ -157,7 +157,7 @@ func (c *Container) diffContainer(container *dc.Container, status *resource.Stat
 
 	image, err := c.client.FindImage(container.Image)
 	if err != nil {
-		status.WarningLevel = resource.StatusFatal
+		status.Level = resource.StatusFatal
 		return errors.Wrapf(err, "failed to find image %s for container %s", container.Image, container.Name)
 	}
 

--- a/resource/docker/container/container_test.go
+++ b/resource/docker/container/container_test.go
@@ -139,7 +139,7 @@ func TestContainerCheckStatusNoChange(t *testing.T) {
 		},
 	}
 
-	container := &container.Container{Force: true, Name: "nginx", Status: "created"}
+	container := &container.Container{Force: true, Name: "nginx", CStatus: "created"}
 	container.SetClient(c)
 
 	status, err := container.Check(fakerenderer.New())

--- a/resource/docker/container/container_test.go
+++ b/resource/docker/container/container_test.go
@@ -638,7 +638,7 @@ func TestContainerApply(t *testing.T) {
 	container := &container.Container{Force: true, Name: "nginx", Image: "nginx:latest"}
 	container.SetClient(c)
 
-	_, err := container.Apply(fakerenderer.New())
+	_, err := container.Apply()
 	assert.NoError(t, err)
 }
 

--- a/resource/docker/container/container_test.go
+++ b/resource/docker/container/container_test.go
@@ -47,7 +47,6 @@ func TestContainerCheckContainerNotFound(t *testing.T) {
 	status, err := container.Check(fakerenderer.New())
 	assert.NoError(t, err)
 	assert.True(t, status.HasChanges())
-	assert.Equal(t, name, status.Value())
 	assertDiff(t, status.Diffs(), "name", "<container-missing>", name)
 }
 

--- a/resource/docker/container/preparer.go
+++ b/resource/docker/container/preparer.go
@@ -170,7 +170,7 @@ func (p *Preparer) Prepare(render resource.Renderer) (resource.Task, error) {
 	container := &Container{
 		Force:           force,
 		Name:            name,
-		Status:          status,
+		CStatus:         status,
 		Image:           image,
 		Entrypoint:      renderedEntrypoint,
 		Command:         renderedCommand,
@@ -189,9 +189,9 @@ func (p *Preparer) Prepare(render resource.Renderer) (resource.Task, error) {
 }
 
 func validateContainer(container *Container) error {
-	if container.Status != "" {
-		if !strings.EqualFold(container.Status, containerStatusRunning) &&
-			!strings.EqualFold(container.Status, containerStatusCreated) {
+	if container.CStatus != "" {
+		if !strings.EqualFold(container.CStatus, containerStatusRunning) &&
+			!strings.EqualFold(container.CStatus, containerStatusCreated) {
 			return errors.New("status must be 'running' or 'created'")
 		}
 	}

--- a/resource/docker/image/image.go
+++ b/resource/docker/image/image.go
@@ -52,7 +52,7 @@ func (i *Image) Check(resource.Renderer) (resource.TaskStatus, error) {
 }
 
 // Apply pulls a docker image
-func (i *Image) Apply(r resource.Renderer) (resource.TaskStatus, error) {
+func (i *Image) Apply() (resource.TaskStatus, error) {
 	if err := i.client.PullImage(i.Name, i.Tag); err != nil {
 		return &resource.Status{
 			WarningLevel: resource.StatusFatal,

--- a/resource/docker/image/image.go
+++ b/resource/docker/image/image.go
@@ -23,6 +23,8 @@ import (
 
 // Image is responsible for pulling docker images
 type Image struct {
+	resource.Status
+
 	Name   string
 	Tag    string
 	client docker.APIClient
@@ -31,11 +33,11 @@ type Image struct {
 // Check system for presence of docker image
 func (i *Image) Check(resource.Renderer) (resource.TaskStatus, error) {
 	repoTag := i.RepoTag()
-	status := &resource.Status{Status: repoTag}
+	i.Status.Status = repoTag
 	image, err := i.client.FindImage(repoTag)
 	if err != nil {
-		status.WarningLevel = resource.StatusFatal
-		return status, err
+		i.Status.WarningLevel = resource.StatusFatal
+		return i, err
 	}
 
 	var original string
@@ -43,12 +45,12 @@ func (i *Image) Check(resource.Renderer) (resource.TaskStatus, error) {
 		original = repoTag
 	}
 
-	status.AddDifference("image", original, repoTag, "<image-missing>")
-	if resource.AnyChanges(status.Differences) {
-		status.WillChange = true
-		status.WarningLevel = resource.StatusWillChange
+	i.Status.AddDifference("image", original, repoTag, "<image-missing>")
+	if resource.AnyChanges(i.Status.Differences) {
+		i.Status.WillChange = true
+		i.Status.WarningLevel = resource.StatusWillChange
 	}
-	return status, nil
+	return i, nil
 }
 
 // Apply pulls a docker image
@@ -59,7 +61,8 @@ func (i *Image) Apply() (resource.TaskStatus, error) {
 			Status:       fmt.Sprintf("%s", err),
 		}, err
 	}
-	return &resource.Status{Status: i.RepoTag()}, nil
+	i.Status = resource.Status{Status: i.RepoTag()}
+	return i, nil
 }
 
 // SetClient injects a docker api client

--- a/resource/docker/image/image.go
+++ b/resource/docker/image/image.go
@@ -33,7 +33,6 @@ type Image struct {
 // Check system for presence of docker image
 func (i *Image) Check(resource.Renderer) (resource.TaskStatus, error) {
 	repoTag := i.RepoTag()
-	i.Status.Status = repoTag
 	image, err := i.client.FindImage(repoTag)
 	if err != nil {
 		i.Status.WarningLevel = resource.StatusFatal
@@ -58,10 +57,9 @@ func (i *Image) Apply() (resource.TaskStatus, error) {
 	if err := i.client.PullImage(i.Name, i.Tag); err != nil {
 		return &resource.Status{
 			WarningLevel: resource.StatusFatal,
-			Status:       fmt.Sprintf("%s", err),
+			Output:       []string{err.Error()},
 		}, err
 	}
-	i.Status = resource.Status{Status: i.RepoTag()}
 	return i, nil
 }
 

--- a/resource/docker/image/image.go
+++ b/resource/docker/image/image.go
@@ -46,7 +46,6 @@ func (i *Image) Check(resource.Renderer) (resource.TaskStatus, error) {
 
 	i.Status.AddDifference("image", original, repoTag, "<image-missing>")
 	if resource.AnyChanges(i.Status.Differences) {
-		i.Status.WillChange = true
 		i.Status.WarningLevel = resource.StatusWillChange
 	}
 	return i, nil

--- a/resource/docker/image/image.go
+++ b/resource/docker/image/image.go
@@ -35,7 +35,7 @@ func (i *Image) Check(resource.Renderer) (resource.TaskStatus, error) {
 	repoTag := i.RepoTag()
 	image, err := i.client.FindImage(repoTag)
 	if err != nil {
-		i.Status.WarningLevel = resource.StatusFatal
+		i.Status.Level = resource.StatusFatal
 		return i, err
 	}
 
@@ -46,7 +46,7 @@ func (i *Image) Check(resource.Renderer) (resource.TaskStatus, error) {
 
 	i.Status.AddDifference("image", original, repoTag, "<image-missing>")
 	if resource.AnyChanges(i.Status.Differences) {
-		i.Status.WarningLevel = resource.StatusWillChange
+		i.Status.Level = resource.StatusWillChange
 	}
 	return i, nil
 }
@@ -55,8 +55,8 @@ func (i *Image) Check(resource.Renderer) (resource.TaskStatus, error) {
 func (i *Image) Apply() (resource.TaskStatus, error) {
 	if err := i.client.PullImage(i.Name, i.Tag); err != nil {
 		return &resource.Status{
-			WarningLevel: resource.StatusFatal,
-			Output:       []string{err.Error()},
+			Level:  resource.StatusFatal,
+			Output: []string{err.Error()},
 		}, err
 	}
 	return i, nil

--- a/resource/docker/image/image_test.go
+++ b/resource/docker/image/image_test.go
@@ -117,7 +117,7 @@ func TestImageApply(t *testing.T) {
 	}
 	image := &image.Image{Name: "ubuntu", Tag: "precise"}
 	image.SetClient(c)
-	_, applyError := image.Apply(fakerenderer.New())
+	_, applyError := image.Apply()
 	assert.NoError(t, applyError)
 }
 
@@ -133,7 +133,7 @@ func TestImageApplyTimedOut(t *testing.T) {
 	image := &image.Image{Name: "ubuntu", Tag: "precise"}
 	image.SetClient(c)
 
-	_, err := image.Apply(fakerenderer.New())
+	_, err := image.Apply()
 	if assert.Error(t, err) {
 		assert.EqualError(t, err, "inactivity time exceeded timeout")
 	}

--- a/resource/docker/image/image_test.go
+++ b/resource/docker/image/image_test.go
@@ -66,7 +66,6 @@ func TestImageCheckImageNeedsChange(t *testing.T) {
 	assert.True(t, status.HasChanges())
 	assert.Equal(t, "<image-missing>", status.Diffs()["image"].Original())
 	assert.Equal(t, "ubuntu:precise", status.Diffs()["image"].Current())
-	assert.Equal(t, "ubuntu:precise", status.Value())
 }
 
 func TestImageCheckImageNoChange(t *testing.T) {
@@ -85,7 +84,6 @@ func TestImageCheckImageNoChange(t *testing.T) {
 	assert.False(t, status.HasChanges())
 	assert.Equal(t, "ubuntu:precise", status.Diffs()["image"].Original())
 	assert.Equal(t, "ubuntu:precise", status.Diffs()["image"].Current())
-	assert.Equal(t, "ubuntu:precise", status.Value())
 }
 
 func TestImageCheckFailed(t *testing.T) {

--- a/resource/file/content/content.go
+++ b/resource/file/content/content.go
@@ -81,7 +81,7 @@ func (t *Content) Check(resource.Renderer) (resource.TaskStatus, error) {
 }
 
 // Apply writes the content to disk
-func (t *Content) Apply(r resource.Renderer) (resource.TaskStatus, error) {
+func (t *Content) Apply() (resource.TaskStatus, error) {
 	var perm os.FileMode
 	var preChange string
 	diffs := make(map[string]resource.Diff)
@@ -91,7 +91,11 @@ func (t *Content) Apply(r resource.Renderer) (resource.TaskStatus, error) {
 		diffs["mode"] = resource.TextDiff{Values: [2]string{"not set", "0600"}}
 		perm = 0600
 	} else if err != nil {
-		return t.Check(r)
+		return &resource.Status{
+			WarningLevel: resource.StatusFatal,
+			WillChange:   true,
+			Output:       []string{err.Error()},
+		}, err
 	} else {
 		perm = stat.Mode()
 	}

--- a/resource/file/content/content.go
+++ b/resource/file/content/content.go
@@ -39,7 +39,6 @@ func (t *Content) Check(resource.Renderer) (resource.TaskStatus, error) {
 		diffs[t.Destination] = contentDiff
 		t.Status = &resource.Status{
 			WarningLevel: resource.StatusWillChange,
-			WillChange:   true,
 			Differences:  diffs,
 			Output:       []string{t.Destination + ": File is missing"},
 		}
@@ -52,8 +51,7 @@ func (t *Content) Check(resource.Renderer) (resource.TaskStatus, error) {
 		return t, err
 	} else if stat.IsDir() {
 		t.Status = &resource.Status{
-			WarningLevel: resource.StatusFatal,
-			WillChange:   true,
+			WarningLevel: resource.StatusCantChange,
 			Output:       []string{t.Destination + " is a directory"},
 		}
 		return t, fmt.Errorf("cannot update contents of %q, it is a directory", t.Destination)
@@ -75,7 +73,6 @@ func (t *Content) Check(resource.Renderer) (resource.TaskStatus, error) {
 	t.Status = &resource.Status{
 		Output:      []string{statusMessage},
 		Differences: diffs,
-		WillChange:  resource.AnyChanges(diffs),
 	}
 	return t, nil
 }
@@ -93,7 +90,6 @@ func (t *Content) Apply() (resource.TaskStatus, error) {
 	} else if err != nil {
 		return &resource.Status{
 			WarningLevel: resource.StatusFatal,
-			WillChange:   true,
 			Output:       []string{err.Error()},
 		}, err
 	} else {

--- a/resource/file/content/content.go
+++ b/resource/file/content/content.go
@@ -38,21 +38,21 @@ func (t *Content) Check(resource.Renderer) (resource.TaskStatus, error) {
 		contentDiff.Values[0] = "<file-missing>"
 		diffs[t.Destination] = contentDiff
 		t.Status = &resource.Status{
-			WarningLevel: resource.StatusWillChange,
-			Differences:  diffs,
-			Output:       []string{t.Destination + ": File is missing"},
+			Level:       resource.StatusWillChange,
+			Differences: diffs,
+			Output:      []string{t.Destination + ": File is missing"},
 		}
 		return t, nil
 	} else if err != nil {
 		t.Status = &resource.Status{
-			WarningLevel: resource.StatusFatal,
-			Output:       []string{"Cannot read `" + t.Destination + "`"},
+			Level:  resource.StatusFatal,
+			Output: []string{"Cannot read `" + t.Destination + "`"},
 		}
 		return t, err
 	} else if stat.IsDir() {
 		t.Status = &resource.Status{
-			WarningLevel: resource.StatusCantChange,
-			Output:       []string{t.Destination + " is a directory"},
+			Level:  resource.StatusCantChange,
+			Output: []string{t.Destination + " is a directory"},
 		}
 		return t, fmt.Errorf("cannot update contents of %q, it is a directory", t.Destination)
 	}
@@ -89,8 +89,8 @@ func (t *Content) Apply() (resource.TaskStatus, error) {
 		perm = 0600
 	} else if err != nil {
 		return &resource.Status{
-			WarningLevel: resource.StatusFatal,
-			Output:       []string{err.Error()},
+			Level:  resource.StatusFatal,
+			Output: []string{err.Error()},
 		}, err
 	} else {
 		perm = stat.Mode()
@@ -106,9 +106,9 @@ func (t *Content) Apply() (resource.TaskStatus, error) {
 
 	if err = ioutil.WriteFile(t.Destination, []byte(t.Content), perm); err != nil {
 		t.Status = &resource.Status{
-			Output:       []string{err.Error()},
-			WarningLevel: resource.StatusFatal,
-			Differences:  diffs,
+			Output:      []string{err.Error()},
+			Level:       resource.StatusFatal,
+			Differences: diffs,
 		}
 		return t, err
 	}

--- a/resource/file/content/content.go
+++ b/resource/file/content/content.go
@@ -41,20 +41,20 @@ func (t *Content) Check(resource.Renderer) (resource.TaskStatus, error) {
 			WarningLevel: resource.StatusWillChange,
 			WillChange:   true,
 			Differences:  diffs,
-			Status:       t.Destination + ": File is missing",
+			Output:       []string{t.Destination + ": File is missing"},
 		}
 		return t, nil
 	} else if err != nil {
 		t.Status = &resource.Status{
 			WarningLevel: resource.StatusFatal,
-			Status:       "Cannot read `" + t.Destination + "`",
+			Output:       []string{"Cannot read `" + t.Destination + "`"},
 		}
 		return t, err
 	} else if stat.IsDir() {
 		t.Status = &resource.Status{
 			WarningLevel: resource.StatusFatal,
 			WillChange:   true,
-			Status:       t.Destination + " is a directory",
+			Output:       []string{t.Destination + " is a directory"},
 		}
 		return t, fmt.Errorf("cannot update contents of %q, it is a directory", t.Destination)
 	}
@@ -73,7 +73,7 @@ func (t *Content) Check(resource.Renderer) (resource.TaskStatus, error) {
 	}
 
 	t.Status = &resource.Status{
-		Status:      statusMessage,
+		Output:      []string{statusMessage},
 		Differences: diffs,
 		WillChange:  resource.AnyChanges(diffs),
 	}
@@ -110,7 +110,7 @@ func (t *Content) Apply() (resource.TaskStatus, error) {
 
 	if err = ioutil.WriteFile(t.Destination, []byte(t.Content), perm); err != nil {
 		t.Status = &resource.Status{
-			Status:       fmt.Sprintf("%s", err),
+			Output:       []string{err.Error()},
 			WarningLevel: resource.StatusFatal,
 			Differences:  diffs,
 		}

--- a/resource/file/content/content_test.go
+++ b/resource/file/content/content_test.go
@@ -78,7 +78,7 @@ func TestContentCheckEmptyDir(t *testing.T) {
 	expected := tmpdir + " is a directory"
 
 	status, err := tmpl.Check(fakerenderer.New())
-	assert.Equal(t, expected, status.Value())
+	assert.Contains(t, status.Messages(), expected)
 	assert.True(t, status.HasChanges())
 	if assert.Error(t, err) {
 		assert.EqualError(
@@ -104,7 +104,7 @@ func TestContentCheckSetsValueToOKWhenEverythingIsOK(t *testing.T) {
 	}
 
 	status, err := tmpl.Check(fakerenderer.New())
-	assert.Equal(t, "OK", status.Value())
+	assert.Contains(t, status.Messages(), "OK")
 	assert.False(t, status.HasChanges())
 	assert.NoError(t, err)
 }

--- a/resource/file/content/content_test.go
+++ b/resource/file/content/content_test.go
@@ -145,7 +145,7 @@ func TestContentApply(t *testing.T) {
 		Content:     "1",
 	}
 
-	_, applyErr := tmpl.Apply(fakerenderer.New())
+	_, applyErr := tmpl.Apply()
 	assert.NoError(t, applyErr)
 
 	// read the new file
@@ -164,7 +164,7 @@ func TestContentApplyPermissionDefault(t *testing.T) {
 		Content:     "1",
 	}
 
-	_, applyErr := tmpl.Apply(fakerenderer.New())
+	_, applyErr := tmpl.Apply()
 	assert.NoError(t, applyErr)
 
 	// stat the new file
@@ -188,7 +188,7 @@ func TestContentApplyKeepPermission(t *testing.T) {
 		Content:     "1",
 	}
 
-	_, applyErr := tmpl.Apply(fakerenderer.New())
+	_, applyErr := tmpl.Apply()
 	assert.NoError(t, applyErr)
 
 	// check permissions matched

--- a/resource/file/directory/directory.go
+++ b/resource/file/directory/directory.go
@@ -45,12 +45,10 @@ func (d *Directory) Check(resource.Renderer) (resource.TaskStatus, error) {
 			return status, errors.Wrapf(err, "could not stat %q")
 
 		case os.IsNotExist(err):
-			status.WillChange = true
-
 			// if we aren't told to create everything, we should fail early
 			// since we can't create the parent directories
 			if !d.CreateAll && dest != d.Destination {
-				status.RaiseLevel(resource.StatusFatal)
+				status.RaiseLevel(resource.StatusCantChange)
 				status.AddMessage(fmt.Sprintf("%q does not exist and will not be created (enable create_all to do this)", dest))
 				status.Differences = nil
 				return status, nil
@@ -60,7 +58,7 @@ func (d *Directory) Check(resource.Renderer) (resource.TaskStatus, error) {
 			status.AddDifference(dest, "<absent>", "<present>", "<absent>")
 
 		case !stat.IsDir():
-			status.RaiseLevel(resource.StatusFatal)
+			status.RaiseLevel(resource.StatusCantChange)
 			status.AddMessage(fmt.Sprintf("%q already exists and is not a directory", dest))
 			return status, nil
 

--- a/resource/file/directory/directory.go
+++ b/resource/file/directory/directory.go
@@ -81,7 +81,7 @@ func (d *Directory) Check(resource.Renderer) (resource.TaskStatus, error) {
 }
 
 // Apply creates the directory
-func (d *Directory) Apply(resource.Renderer) (resource.TaskStatus, error) {
+func (d *Directory) Apply() (resource.TaskStatus, error) {
 	var err error
 
 	if d.CreateAll {

--- a/resource/file/directory/directory_test.go
+++ b/resource/file/directory/directory_test.go
@@ -110,7 +110,7 @@ func TestDirectoryCheck(t *testing.T) {
 			[]string{fmt.Sprintf("%q does not exist and will not be created (enable create_all to do this)", path.Dir(dest))},
 			plan.Messages(),
 		)
-		assert.Equal(t, resource.StatusFatal, plan.StatusCode())
+		assert.Equal(t, resource.StatusCantChange, plan.StatusCode())
 		assert.Empty(t, plan.Diffs())
 	})
 
@@ -123,13 +123,13 @@ func TestDirectoryCheck(t *testing.T) {
 		plan, err := dir.Check(fakerenderer.New())
 		require.NoError(t, err)
 
-		assert.False(t, plan.HasChanges())
+		assert.True(t, plan.HasChanges())
 		assert.Equal(
 			t,
 			[]string{fmt.Sprintf("%q already exists and is not a directory", dest)},
 			plan.Messages(),
 		)
-		assert.Equal(t, resource.StatusFatal, plan.StatusCode())
+		assert.Equal(t, resource.StatusCantChange, plan.StatusCode())
 		assert.Empty(t, plan.Diffs())
 	})
 }

--- a/resource/file/directory/directory_test.go
+++ b/resource/file/directory/directory_test.go
@@ -143,7 +143,7 @@ func TestDirectoryApply(t *testing.T) {
 		dest := path.Join(tmpDir, "one-level")
 		dir := directory.Directory{Destination: dest}
 
-		apply, err := dir.Apply(fakerenderer.New())
+		apply, err := dir.Apply()
 		require.NoError(t, err)
 
 		assert.Equal(
@@ -161,7 +161,7 @@ func TestDirectoryApply(t *testing.T) {
 			CreateAll:   true,
 		}
 
-		apply, err := dir.Apply(fakerenderer.New())
+		apply, err := dir.Apply()
 		require.NoError(t, err)
 
 		assert.Equal(
@@ -179,7 +179,7 @@ func TestDirectoryApply(t *testing.T) {
 
 		dir := directory.Directory{Destination: dest}
 
-		_, err := dir.Apply(fakerenderer.New())
+		_, err := dir.Apply()
 		require.Error(t, err)
 	})
 }

--- a/resource/file/mode/mode.go
+++ b/resource/file/mode/mode.go
@@ -37,9 +37,9 @@ func (t *Mode) Check(resource.Renderer) (resource.TaskStatus, error) {
 		diffs[t.Destination] = &FileModeDiff{Expected: t.Mode}
 		status := fmt.Sprintf("%q does not exist", t.Destination)
 		return &resource.Status{
-			WarningLevel: resource.StatusFatal,
-			Differences:  diffs,
-			Output:       []string{status},
+			Level:       resource.StatusFatal,
+			Differences: diffs,
+			Output:      []string{status},
 		}, nil
 	} else if err != nil {
 		return nil, err
@@ -54,8 +54,8 @@ func (t *Mode) Check(resource.Renderer) (resource.TaskStatus, error) {
 	}
 
 	t.Status = resource.Status{
-		WarningLevel: warningLevel,
-		Differences:  diffs,
+		Level:       warningLevel,
+		Differences: diffs,
 		Output: []string{
 			fmt.Sprintf("%q exist", t.Destination),
 			status,
@@ -70,8 +70,8 @@ func (t *Mode) Apply() (resource.TaskStatus, error) {
 
 	if err != nil {
 		return &resource.Status{
-			WarningLevel: resource.StatusFatal,
-			Output:       []string{fmt.Sprintf("failed to set mode on %s: %s", t.Destination, err)},
+			Level:  resource.StatusFatal,
+			Output: []string{fmt.Sprintf("failed to set mode on %s: %s", t.Destination, err)},
 		}, err
 	}
 

--- a/resource/file/mode/mode.go
+++ b/resource/file/mode/mode.go
@@ -37,7 +37,6 @@ func (t *Mode) Check(resource.Renderer) (resource.TaskStatus, error) {
 		diffs[t.Destination] = &FileModeDiff{Expected: t.Mode}
 		status := fmt.Sprintf("%q does not exist", t.Destination)
 		return &resource.Status{
-			Status:       status,
 			WarningLevel: resource.StatusFatal,
 			WillChange:   false,
 			Differences:  diffs,
@@ -56,7 +55,6 @@ func (t *Mode) Check(resource.Renderer) (resource.TaskStatus, error) {
 	}
 
 	t.Status = resource.Status{
-		Status:       status,
 		WarningLevel: warningLevel,
 		WillChange:   modeDiff.Changes(),
 		Differences:  diffs,

--- a/resource/file/mode/mode.go
+++ b/resource/file/mode/mode.go
@@ -38,7 +38,6 @@ func (t *Mode) Check(resource.Renderer) (resource.TaskStatus, error) {
 		status := fmt.Sprintf("%q does not exist", t.Destination)
 		return &resource.Status{
 			WarningLevel: resource.StatusFatal,
-			WillChange:   false,
 			Differences:  diffs,
 			Output:       []string{status},
 		}, nil
@@ -56,7 +55,6 @@ func (t *Mode) Check(resource.Renderer) (resource.TaskStatus, error) {
 
 	t.Status = resource.Status{
 		WarningLevel: warningLevel,
-		WillChange:   modeDiff.Changes(),
 		Differences:  diffs,
 		Output: []string{
 			fmt.Sprintf("%q exist", t.Destination),
@@ -73,7 +71,6 @@ func (t *Mode) Apply() (resource.TaskStatus, error) {
 	if err != nil {
 		return &resource.Status{
 			WarningLevel: resource.StatusFatal,
-			WillChange:   true,
 			Output:       []string{fmt.Sprintf("failed to set mode on %s: %s", t.Destination, err)},
 		}, err
 	}

--- a/resource/file/mode/mode_test.go
+++ b/resource/file/mode/mode_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/asteris-llc/converge/resource"
 	"github.com/asteris-llc/converge/resource/file/mode"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTemplateInterface(t *testing.T) {
@@ -53,8 +54,8 @@ func TestApply(t *testing.T) {
 	defer os.Remove(tmpfile.Name())
 
 	mode := mode.Mode{Destination: tmpfile.Name(), Mode: os.FileMode(int(0777))}
-	_, err = mode.Apply(fakerenderer.New())
-	assert.NoError(t, err)
+	_, err = mode.Apply()
+	require.NoError(t, err)
 	status, err := mode.Check(fakerenderer.New())
 	assert.NoError(t, err)
 	assert.Equal(t, fmt.Sprintf("%q's mode is \"-rwxrwxrwx\" expected \"-rwxrwxrwx\"", tmpfile.Name()), status.Value())

--- a/resource/file/mode/mode_test.go
+++ b/resource/file/mode/mode_test.go
@@ -43,7 +43,7 @@ func TestCheck(t *testing.T) {
 
 	status, err := mode.Check(fakerenderer.New())
 	assert.NoError(t, err)
-	assert.Equal(t, fmt.Sprintf("%q's mode is \"-rw-------\" expected \"-rwxrwxrwx\"", tmpfile.Name()), status.Value())
+	assert.Contains(t, status.Messages(), fmt.Sprintf("%q's mode is \"-rw-------\" expected \"-rwxrwxrwx\"", tmpfile.Name()))
 	assert.True(t, status.HasChanges())
 }
 
@@ -58,6 +58,6 @@ func TestApply(t *testing.T) {
 	require.NoError(t, err)
 	status, err := mode.Check(fakerenderer.New())
 	assert.NoError(t, err)
-	assert.Equal(t, fmt.Sprintf("%q's mode is \"-rwxrwxrwx\" expected \"-rwxrwxrwx\"", tmpfile.Name()), status.Value())
+	assert.Contains(t, status.Messages(), fmt.Sprintf("%q's mode is \"-rwxrwxrwx\" expected \"-rwxrwxrwx\"", tmpfile.Name()))
 	assert.False(t, status.HasChanges())
 }

--- a/resource/group/group.go
+++ b/resource/group/group.go
@@ -128,7 +128,7 @@ func (g *Group) Check(resource.Renderer) (resource.TaskStatus, error) {
 }
 
 // Apply changes for group
-func (g *Group) Apply(resource.Renderer) (resource.TaskStatus, error) {
+func (g *Group) Apply() (resource.TaskStatus, error) {
 	// lookup the group by name and lookup the group by gid
 	// the lookups return ErrUnsupported if the system is not supported
 	// LookupGroup returns user.UnknownGroupError if the group is not found

--- a/resource/group/group.go
+++ b/resource/group/group.go
@@ -70,7 +70,7 @@ func (g *Group) Check(resource.Renderer) (resource.TaskStatus, error) {
 	status := &resource.Status{}
 
 	if nameErr == ErrUnsupported || gidErr == ErrUnsupported {
-		status.WarningLevel = resource.StatusFatal
+		status.Level = resource.StatusFatal
 		return status, ErrUnsupported
 	}
 
@@ -81,20 +81,20 @@ func (g *Group) Check(resource.Renderer) (resource.TaskStatus, error) {
 
 		switch {
 		case nameNotFound && gidNotFound:
-			status.WarningLevel = resource.StatusWillChange
+			status.Level = resource.StatusWillChange
 			status.Output = append(status.Output, "group name and gid do not exist")
 			status.AddDifference("group", string(StateAbsent), fmt.Sprintf("group %s with gid %s", g.Name, g.GID), "")
 		case nameNotFound:
-			status.WarningLevel = resource.StatusFatal
+			status.Level = resource.StatusFatal
 			status.Output = append(status.Output, fmt.Sprintf("group gid %s already exists", g.GID))
 		case gidNotFound:
-			status.WarningLevel = resource.StatusFatal
+			status.Level = resource.StatusFatal
 			status.Output = append(status.Output, fmt.Sprintf("group %s already exists", g.Name))
 		case groupByName != nil && groupByGid != nil && groupByName.Name != groupByGid.Name || groupByName.Gid != groupByGid.Gid:
-			status.WarningLevel = resource.StatusFatal
+			status.Level = resource.StatusFatal
 			status.Output = append(status.Output, fmt.Sprintf("group %s and gid %s belong to different groups", g.Name, g.GID))
 		case groupByName != nil && groupByGid != nil && *groupByName == *groupByGid:
-			status.WarningLevel = resource.StatusNoChange
+			status.Level = resource.StatusNoChange
 		}
 	case StateAbsent:
 		_, nameNotFound := nameErr.(user.UnknownGroupError)
@@ -102,23 +102,23 @@ func (g *Group) Check(resource.Renderer) (resource.TaskStatus, error) {
 
 		switch {
 		case nameNotFound && gidNotFound:
-			status.WarningLevel = resource.StatusNoChange
+			status.Level = resource.StatusNoChange
 			status.Output = append(status.Output, "group name and gid do not exist")
 		case nameNotFound:
-			status.WarningLevel = resource.StatusFatal
+			status.Level = resource.StatusFatal
 			status.Output = append(status.Output, fmt.Sprintf("group %s does not exist", g.Name))
 		case gidNotFound:
-			status.WarningLevel = resource.StatusFatal
+			status.Level = resource.StatusFatal
 			status.Output = append(status.Output, fmt.Sprintf("group gid %s does not exist", g.GID))
 		case groupByName != nil && groupByGid != nil && groupByName.Name != groupByGid.Name || groupByName.Gid != groupByGid.Gid:
-			status.WarningLevel = resource.StatusFatal
+			status.Level = resource.StatusFatal
 			status.Output = append(status.Output, fmt.Sprintf("group %s and gid %s belong to different groups", g.Name, g.GID))
 		case groupByName != nil && groupByGid != nil && *groupByName == *groupByGid:
-			status.WarningLevel = resource.StatusWillChange
+			status.Level = resource.StatusWillChange
 			status.AddDifference("group", fmt.Sprintf("group %s with gid %s", g.Name, g.GID), string(StateAbsent), "")
 		}
 	default:
-		status.WarningLevel = resource.StatusFatal
+		status.Level = resource.StatusFatal
 		return status, fmt.Errorf("group: unrecognized state %v", g.State)
 	}
 
@@ -137,7 +137,7 @@ func (g *Group) Apply() (resource.TaskStatus, error) {
 	status := &resource.Status{}
 
 	if nameErr == ErrUnsupported || gidErr == ErrUnsupported {
-		status.WarningLevel = resource.StatusFatal
+		status.Level = resource.StatusFatal
 		return status, ErrUnsupported
 	}
 
@@ -150,13 +150,13 @@ func (g *Group) Apply() (resource.TaskStatus, error) {
 		case nameNotFound && gidNotFound:
 			err := g.system.AddGroup(g.Name, g.GID)
 			if err != nil {
-				status.WarningLevel = resource.StatusFatal
+				status.Level = resource.StatusFatal
 				status.Output = append(status.Output, fmt.Sprintf("error adding group %s with gid %s", g.Name, g.GID))
 				return status, err
 			}
 			status.Output = append(status.Output, fmt.Sprintf("added group %s with gid %s", g.Name, g.GID))
 		default:
-			status.WarningLevel = resource.StatusFatal
+			status.Level = resource.StatusFatal
 			return status, fmt.Errorf("will not attempt add: group %s with gid %s", g.Name, g.GID)
 		}
 	case StateAbsent:
@@ -164,17 +164,17 @@ func (g *Group) Apply() (resource.TaskStatus, error) {
 		case groupByName != nil && groupByGid != nil && *groupByName == *groupByGid:
 			err := g.system.DelGroup(g.Name)
 			if err != nil {
-				status.WarningLevel = resource.StatusFatal
+				status.Level = resource.StatusFatal
 				status.Output = append(status.Output, fmt.Sprintf("error deleting group %s with gid %s", g.Name, g.GID))
 				return status, err
 			}
 			status.Output = append(status.Output, fmt.Sprintf("deleted group %s with gid %s", g.Name, g.GID))
 		default:
-			status.WarningLevel = resource.StatusFatal
+			status.Level = resource.StatusFatal
 			return status, fmt.Errorf("will not attempt delete: group %s with gid %s", g.Name, g.GID)
 		}
 	default:
-		status.WarningLevel = resource.StatusFatal
+		status.Level = resource.StatusFatal
 		return status, fmt.Errorf("group: unrecognized state %s", g.State)
 	}
 

--- a/resource/group/group.go
+++ b/resource/group/group.go
@@ -91,7 +91,7 @@ func (g *Group) Check(resource.Renderer) (resource.TaskStatus, error) {
 			status.Level = resource.StatusFatal
 			status.Output = append(status.Output, fmt.Sprintf("group %s already exists", g.Name))
 		case groupByName != nil && groupByGid != nil && groupByName.Name != groupByGid.Name || groupByName.Gid != groupByGid.Gid:
-			status.Level = resource.StatusFatal
+			status.Level = resource.StatusCantChange
 			status.Output = append(status.Output, fmt.Sprintf("group %s and gid %s belong to different groups", g.Name, g.GID))
 		case groupByName != nil && groupByGid != nil && *groupByName == *groupByGid:
 			status.Level = resource.StatusNoChange
@@ -111,7 +111,7 @@ func (g *Group) Check(resource.Renderer) (resource.TaskStatus, error) {
 			status.Level = resource.StatusFatal
 			status.Output = append(status.Output, fmt.Sprintf("group gid %s does not exist", g.GID))
 		case groupByName != nil && groupByGid != nil && groupByName.Name != groupByGid.Name || groupByName.Gid != groupByGid.Gid:
-			status.Level = resource.StatusFatal
+			status.Level = resource.StatusCantChange
 			status.Output = append(status.Output, fmt.Sprintf("group %s and gid %s belong to different groups", g.Name, g.GID))
 		case groupByName != nil && groupByGid != nil && *groupByName == *groupByGid:
 			status.Level = resource.StatusWillChange
@@ -156,7 +156,7 @@ func (g *Group) Apply() (resource.TaskStatus, error) {
 			}
 			status.Output = append(status.Output, fmt.Sprintf("added group %s with gid %s", g.Name, g.GID))
 		default:
-			status.Level = resource.StatusFatal
+			status.Level = resource.StatusCantChange
 			return status, fmt.Errorf("will not attempt add: group %s with gid %s", g.Name, g.GID)
 		}
 	case StateAbsent:
@@ -170,7 +170,7 @@ func (g *Group) Apply() (resource.TaskStatus, error) {
 			}
 			status.Output = append(status.Output, fmt.Sprintf("deleted group %s with gid %s", g.Name, g.GID))
 		default:
-			status.Level = resource.StatusFatal
+			status.Level = resource.StatusCantChange
 			return status, fmt.Errorf("will not attempt delete: group %s with gid %s", g.Name, g.GID)
 		}
 	default:

--- a/resource/group/group.go
+++ b/resource/group/group.go
@@ -84,7 +84,6 @@ func (g *Group) Check(resource.Renderer) (resource.TaskStatus, error) {
 			status.WarningLevel = resource.StatusWillChange
 			status.Output = append(status.Output, "group name and gid do not exist")
 			status.AddDifference("group", string(StateAbsent), fmt.Sprintf("group %s with gid %s", g.Name, g.GID), "")
-			status.WillChange = true
 		case nameNotFound:
 			status.WarningLevel = resource.StatusFatal
 			status.Output = append(status.Output, fmt.Sprintf("group gid %s already exists", g.GID))
@@ -116,7 +115,6 @@ func (g *Group) Check(resource.Renderer) (resource.TaskStatus, error) {
 			status.Output = append(status.Output, fmt.Sprintf("group %s and gid %s belong to different groups", g.Name, g.GID))
 		case groupByName != nil && groupByGid != nil && *groupByName == *groupByGid:
 			status.WarningLevel = resource.StatusWillChange
-			status.WillChange = true
 			status.AddDifference("group", fmt.Sprintf("group %s with gid %s", g.Name, g.GID), string(StateAbsent), "")
 		}
 	default:

--- a/resource/group/group_test.go
+++ b/resource/group/group_test.go
@@ -208,9 +208,9 @@ func TestCheckNameAndGidMismatchStatePresent(t *testing.T) {
 
 	if runtime.GOOS == "linux" {
 		assert.NoError(t, err)
-		assert.Equal(t, resource.StatusFatal, status.StatusCode())
+		assert.Equal(t, resource.StatusCantChange, status.StatusCode())
 		assert.Equal(t, fmt.Sprintf("group %s and gid %s belong to different groups", g.Name, g.GID), status.Messages()[0])
-		assert.False(t, status.HasChanges())
+		assert.True(t, status.HasChanges())
 	} else {
 		assert.EqualError(t, err, "group: not supported on this system")
 	}
@@ -231,9 +231,9 @@ func TestCheckNameAndGidMismatchStateAbsent(t *testing.T) {
 
 	if runtime.GOOS == "linux" {
 		assert.NoError(t, err)
-		assert.Equal(t, resource.StatusFatal, status.StatusCode())
+		assert.Equal(t, resource.StatusCantChange, status.StatusCode())
 		assert.Equal(t, fmt.Sprintf("group %s and gid %s belong to different groups", g.Name, g.GID), status.Messages()[0])
-		assert.False(t, status.HasChanges())
+		assert.True(t, status.HasChanges())
 	} else {
 		assert.EqualError(t, err, "group: not supported on this system")
 	}

--- a/resource/group/group_test.go
+++ b/resource/group/group_test.go
@@ -311,7 +311,7 @@ func TestApplyAddGroup(t *testing.T) {
 	m.On("LookupGroup", g.Name).Return(grp, user.UnknownGroupError(""))
 	m.On("LookupGroupID", g.GID).Return(grp, user.UnknownGroupIdError(""))
 	m.On("AddGroup", g.Name, g.GID).Return(nil)
-	status, err := g.Apply(fakerenderer.New())
+	status, err := g.Apply()
 
 	m.AssertCalled(t, "AddGroup", g.Name, g.GID)
 	assert.NoError(t, err)
@@ -334,7 +334,7 @@ func TestApplyDeleteGroup(t *testing.T) {
 	m.On("LookupGroup", g.Name).Return(grp, nil)
 	m.On("LookupGroupID", g.GID).Return(grp, nil)
 	m.On("DelGroup", g.Name).Return(nil)
-	status, err := g.Apply(fakerenderer.New())
+	status, err := g.Apply()
 
 	m.AssertCalled(t, "DelGroup", g.Name)
 	assert.NoError(t, err)
@@ -357,7 +357,7 @@ func TestApplyAddGroupErrorAdding(t *testing.T) {
 	m.On("LookupGroup", g.Name).Return(grp, user.UnknownGroupError(""))
 	m.On("LookupGroupID", g.GID).Return(grp, user.UnknownGroupIdError(""))
 	m.On("AddGroup", g.Name, g.GID).Return(fmt.Errorf(""))
-	status, err := g.Apply(fakerenderer.New())
+	status, err := g.Apply()
 
 	m.AssertCalled(t, "AddGroup", g.Name, g.GID)
 	assert.EqualError(t, err, fmt.Sprintf(""))
@@ -381,7 +381,7 @@ func TestApplyAddGroupNotAdded(t *testing.T) {
 	m.On("LookupGroup", g.Name).Return(grp, nil)
 	m.On("LookupGroupID", g.GID).Return(grp, nil)
 	m.On("AddGroup", g.Name, g.GID).Return(nil)
-	status, err := g.Apply(fakerenderer.New())
+	status, err := g.Apply()
 
 	m.AssertNotCalled(t, "AddGroup", g.Name, g.GID)
 	assert.EqualError(t, err, fmt.Sprintf("will not attempt add: group %s with gid %s", g.Name, g.GID))
@@ -404,7 +404,7 @@ func TestApplyDeleteGroupErrorDeleting(t *testing.T) {
 	m.On("LookupGroup", g.Name).Return(grp, nil)
 	m.On("LookupGroupID", g.GID).Return(grp, nil)
 	m.On("DelGroup", g.Name).Return(fmt.Errorf(""))
-	status, err := g.Apply(fakerenderer.New())
+	status, err := g.Apply()
 
 	m.AssertCalled(t, "DelGroup", g.Name)
 	assert.EqualError(t, err, fmt.Sprintf(""))
@@ -432,7 +432,7 @@ func TestApplyDeleteGroupNotDeleted(t *testing.T) {
 	m.On("LookupGroup", g.Name).Return(grp1, nil)
 	m.On("LookupGroupID", g.GID).Return(grp2, nil)
 	m.On("DelGroup", g.Name).Return(nil)
-	status, err := g.Apply(fakerenderer.New())
+	status, err := g.Apply()
 
 	m.AssertNotCalled(t, "DelGroup", g.Name)
 	assert.EqualError(t, err, fmt.Sprintf("will not attempt delete: group %s with gid %s", g.Name, g.GID))
@@ -456,7 +456,7 @@ func TestApplyStateUnknown(t *testing.T) {
 	m.On("LookupGroupID", g.GID).Return(grp, nil)
 	m.On("AddGroup", g.Name, g.GID)
 	m.On("DelGroup", g.Name)
-	_, err := g.Apply(fakerenderer.New())
+	_, err := g.Apply()
 
 	m.AssertNotCalled(t, "AddGroup", g.Name, g.GID)
 	m.AssertNotCalled(t, "DelGroup", g.Name)

--- a/resource/group/group_test.go
+++ b/resource/group/group_test.go
@@ -385,7 +385,7 @@ func TestApplyAddGroupNotAdded(t *testing.T) {
 
 	m.AssertNotCalled(t, "AddGroup", g.Name, g.GID)
 	assert.EqualError(t, err, fmt.Sprintf("will not attempt add: group %s with gid %s", g.Name, g.GID))
-	assert.Equal(t, resource.StatusFatal, status.StatusCode())
+	assert.Equal(t, resource.StatusCantChange, status.StatusCode())
 }
 
 func TestApplyDeleteGroupErrorDeleting(t *testing.T) {
@@ -436,7 +436,7 @@ func TestApplyDeleteGroupNotDeleted(t *testing.T) {
 
 	m.AssertNotCalled(t, "DelGroup", g.Name)
 	assert.EqualError(t, err, fmt.Sprintf("will not attempt delete: group %s with gid %s", g.Name, g.GID))
-	assert.Equal(t, resource.StatusFatal, status.StatusCode())
+	assert.Equal(t, resource.StatusCantChange, status.StatusCode())
 }
 
 func TestApplyStateUnknown(t *testing.T) {

--- a/resource/module/module.go
+++ b/resource/module/module.go
@@ -30,7 +30,7 @@ type Module struct {
 
 // Check just returns the current value of the moduleeter. It should never have to change.
 func (m *Module) Check(resource.Renderer) (resource.TaskStatus, error) {
-	m.Status = resource.Status{Status: m.String(), WillChange: false}
+	m.Status = resource.Status{Output: []string{m.String()}, WillChange: false}
 
 	return m, nil
 }

--- a/resource/module/module.go
+++ b/resource/module/module.go
@@ -23,17 +23,21 @@ import (
 
 // Module holds stringified values for parameters
 type Module struct {
+	resource.Status
+
 	Params map[string]string
 }
 
 // Check just returns the current value of the moduleeter. It should never have to change.
 func (m *Module) Check(resource.Renderer) (resource.TaskStatus, error) {
-	return &resource.Status{Status: m.String(), WillChange: false}, nil
+	m.Status = resource.Status{Status: m.String(), WillChange: false}
+
+	return m, nil
 }
 
 // Apply doesn't do anything since modules are final values
-func (m *Module) Apply(r resource.Renderer) (resource.TaskStatus, error) {
-	return m.Check(r)
+func (m *Module) Apply() (resource.TaskStatus, error) {
+	return m, nil
 }
 
 // String is the final value of thie Module

--- a/resource/module/module.go
+++ b/resource/module/module.go
@@ -30,7 +30,7 @@ type Module struct {
 
 // Check just returns the current value of the moduleeter. It should never have to change.
 func (m *Module) Check(resource.Renderer) (resource.TaskStatus, error) {
-	m.Status = resource.Status{Output: []string{m.String()}, WillChange: false}
+	m.Status = resource.Status{Output: []string{m.String()}}
 
 	return m, nil
 }

--- a/resource/param/param.go
+++ b/resource/param/param.go
@@ -29,7 +29,7 @@ type Param struct {
 
 // Check just returns the current value of the parameter. It should never have to change.
 func (p *Param) Check(resource.Renderer) (resource.TaskStatus, error) {
-	p.Status = resource.Status{Status: p.String()}
+	p.Status = resource.Status{Output: []string{p.String()}}
 
 	return p, nil
 }

--- a/resource/param/param.go
+++ b/resource/param/param.go
@@ -22,20 +22,24 @@ import (
 
 // Param controls parameter flow inside execution
 type Param struct {
-	Value interface{}
+	resource.Status
+
+	Val interface{}
 }
 
 // Check just returns the current value of the parameter. It should never have to change.
 func (p *Param) Check(resource.Renderer) (resource.TaskStatus, error) {
-	return &resource.Status{Status: p.String()}, nil
+	p.Status = resource.Status{Status: p.String()}
+
+	return p, nil
 }
 
 // Apply doesn't do anything since params are final values
-func (p *Param) Apply(r resource.Renderer) (resource.TaskStatus, error) {
-	return p.Check(r)
+func (p *Param) Apply() (resource.TaskStatus, error) {
+	return p, nil
 }
 
 // String is the final value of this Param
 func (p *Param) String() string {
-	return fmt.Sprintf("%v", p.Value)
+	return fmt.Sprintf("%v", p.Val)
 }

--- a/resource/param/param_test.go
+++ b/resource/param/param_test.go
@@ -35,7 +35,7 @@ func TestParamCheck(t *testing.T) {
 	param := &param.Param{Val: "test"}
 
 	status, err := param.Check(fakerenderer.New())
-	assert.Equal(t, param.Val, status.Value())
+	assert.Contains(t, status.Messages(), param.Val)
 	assert.False(t, status.HasChanges())
 	assert.NoError(t, err)
 }

--- a/resource/param/param_test.go
+++ b/resource/param/param_test.go
@@ -32,10 +32,10 @@ func TestParamInterface(t *testing.T) {
 func TestParamCheck(t *testing.T) {
 	t.Parallel()
 
-	param := &param.Param{Value: "test"}
+	param := &param.Param{Val: "test"}
 
 	status, err := param.Check(fakerenderer.New())
-	assert.Equal(t, param.Value, status.Value())
+	assert.Equal(t, param.Val, status.Value())
 	assert.False(t, status.HasChanges())
 	assert.NoError(t, err)
 }
@@ -44,6 +44,6 @@ func TestParamApply(t *testing.T) {
 	t.Parallel()
 
 	param := new(param.Param)
-	_, err := param.Apply(fakerenderer.New())
+	_, err := param.Apply()
 	assert.NoError(t, err)
 }

--- a/resource/param/preparer.go
+++ b/resource/param/preparer.go
@@ -37,7 +37,7 @@ type Preparer struct {
 // Prepare a new task
 func (p *Preparer) Prepare(render resource.Renderer) (resource.Task, error) {
 	if val, present := render.Value(); present {
-		return &Param{Value: val}, nil
+		return &Param{Val: val}, nil
 	}
 
 	if p.Default == nil {
@@ -61,7 +61,7 @@ func (p *Preparer) Prepare(render resource.Renderer) (resource.Task, error) {
 		return nil, fmt.Errorf("composite values are not allowed in params, but got %T", v)
 	}
 
-	return &Param{Value: def}, nil
+	return &Param{Val: def}, nil
 }
 
 func init() {

--- a/resource/param/preparer_test.go
+++ b/resource/param/preparer_test.go
@@ -46,7 +46,7 @@ func TestPreparerDefault(t *testing.T) {
 		require.True(t, ok, fmt.Sprintf("expected %T, got %T", resultParam, result))
 
 		require.Nil(t, err)
-		assert.Equal(t, prep.Default, resultParam.Value)
+		assert.Equal(t, prep.Default, resultParam.Val)
 	}
 }
 
@@ -84,7 +84,7 @@ func TestPreparerProvided(t *testing.T) {
 	require.True(t, ok, fmt.Sprintf("expected %T, got %T", resultParam, result))
 
 	require.Nil(t, err)
-	assert.Equal(t, "y", resultParam.Value)
+	assert.Equal(t, "y", resultParam.Val)
 }
 
 func TestPreparerRequired(t *testing.T) {

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -23,7 +23,7 @@ type Tasker interface {
 // checks pass.
 type Task interface {
 	Check(Renderer) (TaskStatus, error)
-	Apply(Renderer) (TaskStatus, error)
+	Apply() (TaskStatus, error)
 }
 
 // Resource adds metadata about the executed tasks

--- a/resource/shell/query/query.go
+++ b/resource/shell/query/query.go
@@ -28,7 +28,7 @@ type Query struct {
 
 // Apply is a nop for queries.  Because HasChanges always returns false this
 // should never be executed.
-func (q *Query) Apply(resource.Renderer) (resource.TaskStatus, error) {
+func (q *Query) Apply() (resource.TaskStatus, error) {
 	return nil, errors.New("query apply called but it should never have changes")
 }
 

--- a/resource/shell/query/query_test.go
+++ b/resource/shell/query/query_test.go
@@ -17,7 +17,6 @@ package query_test
 import (
 	"testing"
 
-	"github.com/asteris-llc/converge/helpers/fakerenderer"
 	"github.com/asteris-llc/converge/resource"
 	"github.com/asteris-llc/converge/resource/shell"
 	"github.com/asteris-llc/converge/resource/shell/query"
@@ -32,7 +31,7 @@ func Test_Query_ImplementsTaskInterface(t *testing.T) {
 func Test_Apply_ReturnsError(t *testing.T) {
 	t.Parallel()
 	sh := testQuery()
-	_, actual := sh.Apply(fakerenderer.New())
+	_, actual := sh.Apply()
 	assert.Error(t, actual)
 }
 

--- a/resource/shell/shell.go
+++ b/resource/shell/shell.go
@@ -53,7 +53,7 @@ func (s *Shell) Check(r resource.Renderer) (resource.TaskStatus, error) {
 }
 
 // Apply is a NOP for health checks
-func (s *Shell) Apply(r resource.Renderer) (resource.TaskStatus, error) {
+func (s *Shell) Apply() (resource.TaskStatus, error) {
 	if cg, ok := s.CmdGenerator.(*CommandGenerator); ok {
 		s.CmdGenerator = cg
 	}

--- a/resource/shell/shell.go
+++ b/resource/shell/shell.go
@@ -125,7 +125,7 @@ func (s *Shell) FailingDep(name string, task resource.TaskStatus) {
 		s.HealthStatus = new(resource.HealthStatus)
 		s.HealthStatus.FailingDeps = make(map[string]string)
 	}
-	s.HealthStatus.FailingDeps[name] = task.Value()
+	s.HealthStatus.FailingDeps[name] = name
 }
 
 // HealthCheck performs a health check

--- a/resource/shell/shell.go
+++ b/resource/shell/shell.go
@@ -21,8 +21,6 @@ import (
 	"github.com/asteris-llc/converge/resource"
 )
 
-var outOfOrderMessage = "[WARNING] shell has no status code (maybe ran out-of-order)"
-
 // Shell is a structure representing a task.
 type Shell struct {
 	CmdGenerator CommandExecutor
@@ -79,19 +77,17 @@ func (s *Shell) Diffs() map[string]resource.Diff {
 }
 
 // StatusCode returns the status code of the most recently executed command
-func (s *Shell) StatusCode() int {
+func (s *Shell) StatusCode() resource.StatusLevel {
 	if s.Status == nil {
-		fmt.Println(outOfOrderMessage)
 		return resource.StatusFatal
 	}
-	return int(s.Status.ExitStatus)
+	return resource.StatusLevel(s.Status.ExitStatus)
 }
 
 // Messages returns a summary of the first execution of check and/or apply.
 // Subsequent runs are surpressed.
 func (s *Shell) Messages() (messages []string) {
 	if s.Status == nil {
-		fmt.Println(outOfOrderMessage)
 		return
 	}
 
@@ -111,7 +107,6 @@ func (s *Shell) Messages() (messages []string) {
 // recent run of check.
 func (s *Shell) HasChanges() bool {
 	if s.Status == nil {
-		fmt.Println(outOfOrderMessage)
 		return false
 	}
 	return (s.Status.ExitStatus != 0)

--- a/resource/shell/shell_test.go
+++ b/resource/shell/shell_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/asteris-llc/converge/healthcheck"
 	"github.com/asteris-llc/converge/helpers/fakerenderer"
+	"github.com/asteris-llc/converge/helpers/logging"
 	"github.com/asteris-llc/converge/resource"
 	"github.com/asteris-llc/converge/resource/shell"
 	"github.com/stretchr/testify/assert"
@@ -132,16 +133,18 @@ func Test_Diffs_ReturnsEmptyMap(t *testing.T) {
 // StatusCode
 
 func Test_StatusCode_WhenNoStatus_ReturnsFatal(t *testing.T) {
+	defer logging.HideLogs(t)()
+
 	sh := defaultTestShell()
 	assert.Equal(t, resource.StatusFatal, sh.StatusCode())
 }
 
-func Test_StatusCode_WhenMultipleStatus_ReturnsMostRecentSTatus(t *testing.T) {
-	var expected uint32 = 7
+func Test_StatusCode_WhenMultipleStatus_ReturnsMostRecentStatus(t *testing.T) {
+	var expected resource.StatusLevel = 7
 	status := &shell.CommandResults{ExitStatus: 0}
-	status = status.Cons("", &shell.CommandResults{ExitStatus: expected})
+	status = status.Cons("", &shell.CommandResults{ExitStatus: uint32(expected)})
 	sh := &shell.Shell{Status: status}
-	assert.Equal(t, int(expected), sh.StatusCode())
+	assert.Equal(t, expected, sh.StatusCode())
 }
 
 // Shell context

--- a/resource/shell/shell_test.go
+++ b/resource/shell/shell_test.go
@@ -139,7 +139,9 @@ func Test_StatusCode_WhenNoStatus_ReturnsFatal(t *testing.T) {
 	assert.Equal(t, resource.StatusFatal, sh.StatusCode())
 }
 
-func Test_StatusCode_WhenMultipleStatus_ReturnsMostRecentStatus(t *testing.T) {
+// TestStatusCodeWhenMultipleStatusReturnsMostRecentStatus tests what happens
+// when there are multiple status returns
+func TestStatusCodeWhenMultipleStatusReturnsMostRecentStatus(t *testing.T) {
 	var expected resource.StatusLevel = 7
 	status := &shell.CommandResults{ExitStatus: 0}
 	status = status.Cons("", &shell.CommandResults{ExitStatus: uint32(expected)})

--- a/resource/shell/shell_test.go
+++ b/resource/shell/shell_test.go
@@ -80,7 +80,7 @@ func Test_Apply_WhenRunReturnsError_ReturnsError(t *testing.T) {
 	m := new(MockExecutor)
 	m.On("Run", any).Return(&shell.CommandResults{}, expected)
 	sh := testShell(m)
-	_, actual := sh.Apply(fakerenderer.New())
+	_, actual := sh.Apply()
 	assert.Error(t, actual)
 }
 
@@ -91,7 +91,7 @@ func Test_Apply_WhenRunReturnsResults_PrependsResutsToStatus(t *testing.T) {
 	m.On("Run", any).Return(expectedResult, nil)
 	sh := testShell(m)
 	sh.Status = firstResult
-	_, actual := sh.Apply(fakerenderer.New())
+	_, actual := sh.Apply()
 	assert.NoError(t, actual)
 	assert.Equal(t, expectedResult, sh.Status)
 }
@@ -100,7 +100,7 @@ func Test_Apply_SetsStatusOperationToApply(t *testing.T) {
 	result := &shell.CommandResults{}
 	m := resultExecutor(result)
 	sh := testShell(m)
-	sh.Apply(fakerenderer.New())
+	sh.Apply()
 	assert.Equal(t, "apply", result.ResultsContext.Operation)
 }
 
@@ -108,7 +108,7 @@ func Test_Apply_CallsRunWithApplyStatement(t *testing.T) {
 	statement := "test statement"
 	m := defaultExecutor()
 	sh := &shell.Shell{ApplyStmt: statement, CmdGenerator: m}
-	sh.Apply(fakerenderer.New())
+	sh.Apply()
 	m.AssertCalled(t, "Run", statement)
 }
 

--- a/resource/status.go
+++ b/resource/status.go
@@ -38,7 +38,6 @@ type badDep struct {
 // TaskStatus represents the results of Check called during planning or
 // application.
 type TaskStatus interface {
-	Value() string
 	Diffs() map[string]Diff
 	StatusCode() int
 	Messages() []string
@@ -58,11 +57,9 @@ type Status struct {
 	// initialized properly.
 	Differences map[string]Diff
 
-	// Output and Status are the human-consumable fields on this struct. Output
-	// will be returned as the Status' messages, and Status will be returned as
-	// the Value.
+	// Output is the human-consumable fields on this struct. Output will be
+	// returned as the Status' messages
 	Output []string
-	Status string // TODO(brianhicks): this is kind of a vestigal tail... remove?
 
 	// WarningLevel and WillChange indicate the change level of the status.
 	// WillChange is a binary value, while WarningLevel is a gradation (see the
@@ -77,11 +74,6 @@ func NewStatus() *Status {
 	return &Status{
 		Differences: map[string]Diff{},
 	}
-}
-
-// Value returns the status value
-func (t *Status) Value() string {
-	return t.Status
 }
 
 // Diffs returns the internal differences
@@ -116,14 +108,7 @@ func (t *Status) HealthCheck() (status *HealthStatus, err error) {
 	status.UpgradeWarning(StatusWarning)
 
 	for _, failingDep := range t.FailingDeps {
-		var depMessage string
-		if msg := failingDep.Status.Value(); msg != "" {
-			depMessage = msg
-		} else {
-			depMessage = fmt.Sprintf("returned %d", failingDep.Status.StatusCode())
-		}
-
-		status.FailingDeps[failingDep.ID] = depMessage
+		status.FailingDeps[failingDep.ID] = fmt.Sprintf("returned %d", failingDep.Status.StatusCode())
 	}
 	if t.StatusCode() >= 2 {
 		status.UpgradeWarning(StatusError)

--- a/resource/status.go
+++ b/resource/status.go
@@ -89,11 +89,9 @@ type Status struct {
 	// returned as the Status' messages
 	Output []string
 
-	// WarningLevel and WillChange indicate the change level of the status.
-	// WillChange is a binary value, while WarningLevel is a gradation (see the
-	// Status* contsts above.) Resources should set both for now, if they're
-	// relevant.
-	WarningLevel StatusLevel
+	// Level indicates the change level of the status. Level is a gradation (see
+	// the Status* contsts above.)
+	Level StatusLevel
 }
 
 // NewStatus returns a Status with all fields initialized
@@ -110,7 +108,7 @@ func (t *Status) Diffs() map[string]Diff {
 
 // StatusCode returns the current warning level
 func (t *Status) StatusCode() StatusLevel {
-	return t.WarningLevel
+	return t.Level
 }
 
 // Messages returns the current output slice
@@ -120,7 +118,7 @@ func (t *Status) Messages() []string {
 
 // HasChanges returns the WillChange value
 func (t *Status) HasChanges() bool {
-	if t.WarningLevel == StatusWillChange || t.WarningLevel == StatusCantChange {
+	if t.Level == StatusWillChange || t.Level == StatusCantChange {
 		return true
 	}
 
@@ -170,8 +168,8 @@ func (t *Status) AddMessage(message ...string) {
 
 // RaiseLevel raises the status level to the given level
 func (t *Status) RaiseLevel(level StatusLevel) {
-	if level > t.WarningLevel {
-		t.WarningLevel = level
+	if level > t.Level {
+		t.Level = level
 	}
 }
 

--- a/resource/status_test.go
+++ b/resource/status_test.go
@@ -15,6 +15,7 @@
 package resource_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/asteris-llc/converge/healthcheck"
@@ -24,4 +25,47 @@ import (
 
 func Test_Status_ImplementsCheck(t *testing.T) {
 	assert.Implements(t, (*healthcheck.Check)(nil), new(resource.Status))
+}
+
+func TestHasChanges(t *testing.T) {
+	t.Parallel()
+
+	// by default, statuses will not change
+	t.Run("default", func(t *testing.T) {
+		status := new(resource.Status)
+
+		assert.False(t, status.HasChanges())
+	})
+
+	// Any diffs imply that this resource will change
+	t.Run("diffs", func(t *testing.T) {
+		status := new(resource.Status)
+		status.AddDifference("x", "a", "b", "c")
+
+		assert.True(t, status.HasChanges())
+	})
+
+	// Status level implies changes as well
+	caseTable := []struct {
+		level      resource.StatusLevel
+		willChange bool
+	}{
+		{resource.StatusNoChange, false},
+		{resource.StatusWontChange, false},
+		{resource.StatusWillChange, true},
+		{resource.StatusFatal, false},
+		{resource.StatusCantChange, true},
+	}
+	for _, row := range caseTable {
+		t.Run(
+			fmt.Sprintf("status-%s", row.level),
+			func(t *testing.T) {
+				status := &resource.Status{
+					WarningLevel: row.level,
+				}
+
+				assert.Equal(t, row.willChange, status.HasChanges())
+			},
+		)
+	}
 }

--- a/resource/status_test.go
+++ b/resource/status_test.go
@@ -27,6 +27,7 @@ func Test_Status_ImplementsCheck(t *testing.T) {
 	assert.Implements(t, (*healthcheck.Check)(nil), new(resource.Status))
 }
 
+// TestHasChanges exercises all the cases of HasChanges
 func TestHasChanges(t *testing.T) {
 	t.Parallel()
 

--- a/resource/status_test.go
+++ b/resource/status_test.go
@@ -61,7 +61,7 @@ func TestHasChanges(t *testing.T) {
 			fmt.Sprintf("status-%s", row.level),
 			func(t *testing.T) {
 				status := &resource.Status{
-					WarningLevel: row.level,
+					Level: row.level,
 				}
 
 				assert.Equal(t, row.willChange, status.HasChanges())

--- a/resource/thunktask.go
+++ b/resource/thunktask.go
@@ -29,7 +29,7 @@ func (t *ThunkTask) Check(Renderer) (TaskStatus, error) {
 }
 
 // Apply returns a task status with thunk information
-func (t *ThunkTask) Apply(Renderer) (TaskStatus, error) {
+func (t *ThunkTask) Apply() (TaskStatus, error) {
 	return t.ToStatus(), nil
 }
 

--- a/resource/thunktask.go
+++ b/resource/thunktask.go
@@ -36,8 +36,8 @@ func (t *ThunkTask) Apply() (TaskStatus, error) {
 // ToStatus converts a ThunkStatus to a *Status
 func (t *ThunkTask) ToStatus() *Status {
 	return &Status{
-		WarningLevel: StatusWillChange,
-		Output:       []string{fmt.Sprintf("%s depends on external node execution", t.Name)},
+		Level:  StatusWillChange,
+		Output: []string{fmt.Sprintf("%s depends on external node execution", t.Name)},
 	}
 }
 

--- a/resource/thunktask.go
+++ b/resource/thunktask.go
@@ -37,7 +37,7 @@ func (t *ThunkTask) Apply() (TaskStatus, error) {
 func (t *ThunkTask) ToStatus() *Status {
 	return &Status{
 		WarningLevel: StatusWillChange,
-		Status:       fmt.Sprintf("%s depends on external node execution", t.Name),
+		Output:       []string{fmt.Sprintf("%s depends on external node execution", t.Name)},
 	}
 }
 

--- a/resource/user/user.go
+++ b/resource/user/user.go
@@ -107,7 +107,6 @@ func (u *User) Check(resource.Renderer) (resource.TaskStatus, error) {
 				status.WarningLevel = resource.StatusWillChange
 				status.Output = append(status.Output, "user does not exist")
 				status.AddDifference("user", string(StateAbsent), fmt.Sprintf("user %s", u.Username), "")
-				status.WillChange = true
 			}
 		case u.UID != "":
 			_, nameNotFound := nameErr.(user.UnknownUserError)
@@ -126,7 +125,6 @@ func (u *User) Check(resource.Renderer) (resource.TaskStatus, error) {
 				status.WarningLevel = resource.StatusWillChange
 				status.Output = append(status.Output, "user name and uid do not exist")
 				status.AddDifference("user", string(StateAbsent), fmt.Sprintf("user %s with uid %s", u.Username, u.UID), "")
-				status.WillChange = true
 			case nameNotFound:
 				status.WarningLevel = resource.StatusFatal
 				status.Output = append(status.Output, fmt.Sprintf("user uid %s already exists", u.UID))
@@ -151,7 +149,6 @@ func (u *User) Check(resource.Renderer) (resource.TaskStatus, error) {
 				status.Output = append(status.Output, fmt.Sprintf("user %s does not exist", u.Username))
 			case userByName != nil:
 				status.WarningLevel = resource.StatusWillChange
-				status.WillChange = true
 				status.AddDifference("user", fmt.Sprintf("user %s", u.Username), string(StateAbsent), "")
 			}
 		case u.UID != "":
@@ -173,7 +170,6 @@ func (u *User) Check(resource.Renderer) (resource.TaskStatus, error) {
 				status.Output = append(status.Output, fmt.Sprintf("user %s and uid %s belong to different users", u.Username, u.UID))
 			case userByName != nil && userByID != nil && *userByName == *userByID:
 				status.WarningLevel = resource.StatusWillChange
-				status.WillChange = true
 				status.AddDifference("user", fmt.Sprintf("user %s with uid %s", u.Username, u.UID), string(StateAbsent), "")
 			}
 		}

--- a/resource/user/user.go
+++ b/resource/user/user.go
@@ -81,7 +81,7 @@ func (u *User) Check(resource.Renderer) (resource.TaskStatus, error) {
 	status := &resource.Status{}
 
 	if nameErr == ErrUnsupported {
-		status.WarningLevel = resource.StatusFatal
+		status.Level = resource.StatusFatal
 		return status, ErrUnsupported
 	}
 
@@ -93,18 +93,18 @@ func (u *User) Check(resource.Renderer) (resource.TaskStatus, error) {
 
 			switch {
 			case userByName != nil:
-				status.WarningLevel = resource.StatusFatal
+				status.Level = resource.StatusFatal
 				status.Output = append(status.Output, fmt.Sprintf("user %s already exists", u.Username))
 			case nameNotFound:
 				if u.GID != "" {
 					_, err := u.system.LookupGroupID(u.GID)
 					if err != nil {
-						status.WarningLevel = resource.StatusFatal
+						status.Level = resource.StatusFatal
 						status.Output = append(status.Output, fmt.Sprintf("group gid %s does not exist", u.GID))
 						return status, fmt.Errorf("will not add user %s", u.Username)
 					}
 				}
-				status.WarningLevel = resource.StatusWillChange
+				status.Level = resource.StatusWillChange
 				status.Output = append(status.Output, "user does not exist")
 				status.AddDifference("user", string(StateAbsent), fmt.Sprintf("user %s", u.Username), "")
 			}
@@ -117,25 +117,25 @@ func (u *User) Check(resource.Renderer) (resource.TaskStatus, error) {
 				if u.GID != "" {
 					_, err := u.system.LookupGroupID(u.GID)
 					if err != nil {
-						status.WarningLevel = resource.StatusFatal
+						status.Level = resource.StatusFatal
 						status.Output = append(status.Output, fmt.Sprintf("group gid %s does not exist", u.GID))
 						return status, fmt.Errorf("will not add user %s with uid %s", u.Username, u.UID)
 					}
 				}
-				status.WarningLevel = resource.StatusWillChange
+				status.Level = resource.StatusWillChange
 				status.Output = append(status.Output, "user name and uid do not exist")
 				status.AddDifference("user", string(StateAbsent), fmt.Sprintf("user %s with uid %s", u.Username, u.UID), "")
 			case nameNotFound:
-				status.WarningLevel = resource.StatusFatal
+				status.Level = resource.StatusFatal
 				status.Output = append(status.Output, fmt.Sprintf("user uid %s already exists", u.UID))
 			case uidNotFound:
-				status.WarningLevel = resource.StatusFatal
+				status.Level = resource.StatusFatal
 				status.Output = append(status.Output, fmt.Sprintf("user %s already exists", u.Username))
 			case userByName != nil && userByID != nil && userByName.Name != userByID.Name || userByName.Uid != userByID.Uid:
-				status.WarningLevel = resource.StatusFatal
+				status.Level = resource.StatusFatal
 				status.Output = append(status.Output, fmt.Sprintf("user %s and uid %s belong to different users", u.Username, u.UID))
 			case userByName != nil && userByID != nil && *userByName == *userByID:
-				status.WarningLevel = resource.StatusNoChange
+				status.Level = resource.StatusNoChange
 			}
 		}
 	case StateAbsent:
@@ -145,10 +145,10 @@ func (u *User) Check(resource.Renderer) (resource.TaskStatus, error) {
 
 			switch {
 			case nameNotFound:
-				status.WarningLevel = resource.StatusFatal
+				status.Level = resource.StatusFatal
 				status.Output = append(status.Output, fmt.Sprintf("user %s does not exist", u.Username))
 			case userByName != nil:
-				status.WarningLevel = resource.StatusWillChange
+				status.Level = resource.StatusWillChange
 				status.AddDifference("user", fmt.Sprintf("user %s", u.Username), string(StateAbsent), "")
 			}
 		case u.UID != "":
@@ -157,24 +157,24 @@ func (u *User) Check(resource.Renderer) (resource.TaskStatus, error) {
 
 			switch {
 			case nameNotFound && uidNotFound:
-				status.WarningLevel = resource.StatusNoChange
+				status.Level = resource.StatusNoChange
 				status.Output = append(status.Output, "user name and uid do not exist")
 			case nameNotFound:
-				status.WarningLevel = resource.StatusFatal
+				status.Level = resource.StatusFatal
 				status.Output = append(status.Output, fmt.Sprintf("user %s does not exist", u.Username))
 			case uidNotFound:
-				status.WarningLevel = resource.StatusFatal
+				status.Level = resource.StatusFatal
 				status.Output = append(status.Output, fmt.Sprintf("user uid %s does not exist", u.UID))
 			case userByName != nil && userByID != nil && userByName.Name != userByID.Name || userByName.Uid != userByID.Uid:
-				status.WarningLevel = resource.StatusFatal
+				status.Level = resource.StatusFatal
 				status.Output = append(status.Output, fmt.Sprintf("user %s and uid %s belong to different users", u.Username, u.UID))
 			case userByName != nil && userByID != nil && *userByName == *userByID:
-				status.WarningLevel = resource.StatusWillChange
+				status.Level = resource.StatusWillChange
 				status.AddDifference("user", fmt.Sprintf("user %s with uid %s", u.Username, u.UID), string(StateAbsent), "")
 			}
 		}
 	default:
-		status.WarningLevel = resource.StatusFatal
+		status.Level = resource.StatusFatal
 		return status, fmt.Errorf("user: unrecognized state %v", u.State)
 	}
 
@@ -200,7 +200,7 @@ func (u *User) Apply() (resource.TaskStatus, error) {
 	status := &resource.Status{}
 
 	if nameErr == ErrUnsupported {
-		status.WarningLevel = resource.StatusFatal
+		status.Level = resource.StatusFatal
 		return status, ErrUnsupported
 	}
 
@@ -215,13 +215,13 @@ func (u *User) Apply() (resource.TaskStatus, error) {
 				userAddOptions := SetUserAddOptions(u)
 				err := u.system.AddUser(u.Username, userAddOptions)
 				if err != nil {
-					status.WarningLevel = resource.StatusFatal
+					status.Level = resource.StatusFatal
 					status.Output = append(status.Output, fmt.Sprintf("error adding user %s", u.Username))
 					return status, err
 				}
 				status.Output = append(status.Output, fmt.Sprintf("added user %s", u.Username))
 			default:
-				status.WarningLevel = resource.StatusFatal
+				status.Level = resource.StatusFatal
 				return status, fmt.Errorf("will not attempt add: user %s", u.Username)
 			}
 		case u.UID != "":
@@ -233,13 +233,13 @@ func (u *User) Apply() (resource.TaskStatus, error) {
 				userAddOptions := SetUserAddOptions(u)
 				err := u.system.AddUser(u.Username, userAddOptions)
 				if err != nil {
-					status.WarningLevel = resource.StatusFatal
+					status.Level = resource.StatusFatal
 					status.Output = append(status.Output, fmt.Sprintf("error adding user %s with uid %s", u.Username, u.UID))
 					return status, err
 				}
 				status.Output = append(status.Output, fmt.Sprintf("added user %s with uid %s", u.Username, u.UID))
 			default:
-				status.WarningLevel = resource.StatusFatal
+				status.Level = resource.StatusFatal
 				return status, fmt.Errorf("will not attempt add: user %s with uid %s", u.Username, u.UID)
 			}
 		}
@@ -252,13 +252,13 @@ func (u *User) Apply() (resource.TaskStatus, error) {
 			case !nameNotFound && userByName != nil:
 				err := u.system.DelUser(u.Username)
 				if err != nil {
-					status.WarningLevel = resource.StatusFatal
+					status.Level = resource.StatusFatal
 					status.Output = append(status.Output, fmt.Sprintf("error deleting user %s", u.Username))
 					return status, err
 				}
 				status.Output = append(status.Output, fmt.Sprintf("deleted user %s", u.Username))
 			default:
-				status.WarningLevel = resource.StatusFatal
+				status.Level = resource.StatusFatal
 				return status, fmt.Errorf("will not attempt delete: user %s", u.Username)
 			}
 		case u.UID != "":
@@ -269,18 +269,18 @@ func (u *User) Apply() (resource.TaskStatus, error) {
 			case !nameNotFound && !uidNotFound && userByName != nil && userByID != nil && *userByName == *userByID:
 				err := u.system.DelUser(u.Username)
 				if err != nil {
-					status.WarningLevel = resource.StatusFatal
+					status.Level = resource.StatusFatal
 					status.Output = append(status.Output, fmt.Sprintf("error deleting user %s with uid %s", u.Username, u.UID))
 					return status, err
 				}
 				status.Output = append(status.Output, fmt.Sprintf("deleted user %s with uid %s", u.Username, u.UID))
 			default:
-				status.WarningLevel = resource.StatusFatal
+				status.Level = resource.StatusFatal
 				return status, fmt.Errorf("will not attempt delete: user %s with uid %s", u.Username, u.UID)
 			}
 		}
 	default:
-		status.WarningLevel = resource.StatusFatal
+		status.Level = resource.StatusFatal
 		return status, fmt.Errorf("user: unrecognized state %s", u.State)
 	}
 

--- a/resource/user/user.go
+++ b/resource/user/user.go
@@ -186,7 +186,7 @@ func (u *User) Check(resource.Renderer) (resource.TaskStatus, error) {
 }
 
 // Apply changes for user
-func (u *User) Apply(resource.Renderer) (resource.TaskStatus, error) {
+func (u *User) Apply() (resource.TaskStatus, error) {
 	var (
 		userByID *user.User
 		uidErr   error

--- a/resource/user/user_test.go
+++ b/resource/user/user_test.go
@@ -482,7 +482,7 @@ func TestApplyPresentNoUidAddUser(t *testing.T) {
 
 	m.On("Lookup", u.Username).Return(usr, os.UnknownUserError(""))
 	m.On("AddUser", u.Username, options).Return(nil)
-	status, err := u.Apply(fakerenderer.New())
+	status, err := u.Apply()
 
 	m.AssertCalled(t, "AddUser", u.Username, options)
 	assert.NoError(t, err)
@@ -503,7 +503,7 @@ func TestApplyPresentNoUidAddUserError(t *testing.T) {
 
 	m.On("Lookup", u.Username).Return(usr, os.UnknownUserError(""))
 	m.On("AddUser", u.Username, options).Return(fmt.Errorf(""))
-	status, err := u.Apply(fakerenderer.New())
+	status, err := u.Apply()
 
 	m.AssertCalled(t, "AddUser", u.Username, options)
 	assert.EqualError(t, err, fmt.Sprintf(""))
@@ -525,7 +525,7 @@ func TestApplyPresentNoUidNotAdded(t *testing.T) {
 
 	m.On("Lookup", u.Username).Return(usr, nil)
 	m.On("AddUser", u.Username, options).Return(nil)
-	status, err := u.Apply(fakerenderer.New())
+	status, err := u.Apply()
 
 	m.AssertNotCalled(t, "AddUser", u.Username, options)
 	assert.EqualError(t, err, fmt.Sprintf("will not attempt add: user %s", u.Username))
@@ -549,7 +549,7 @@ func TestApplyPresentWithUidAddUser(t *testing.T) {
 	m.On("Lookup", u.Username).Return(usr, os.UnknownUserError(""))
 	m.On("LookupID", u.UID).Return(usr, os.UnknownUserIdError(1))
 	m.On("AddUser", u.Username, options).Return(nil)
-	status, err := u.Apply(fakerenderer.New())
+	status, err := u.Apply()
 
 	m.AssertCalled(t, "AddUser", u.Username, options)
 	assert.NoError(t, err)
@@ -573,7 +573,7 @@ func TestApplyPresentWithUidAddUserError(t *testing.T) {
 	m.On("Lookup", u.Username).Return(usr, os.UnknownUserError(""))
 	m.On("LookupID", u.UID).Return(usr, os.UnknownUserIdError(1))
 	m.On("AddUser", u.Username, options).Return(fmt.Errorf(""))
-	status, err := u.Apply(fakerenderer.New())
+	status, err := u.Apply()
 
 	m.AssertCalled(t, "AddUser", u.Username, options)
 	assert.EqualError(t, err, fmt.Sprintf(""))
@@ -598,7 +598,7 @@ func TestApplyPresentWithUidNotAdded(t *testing.T) {
 	m.On("Lookup", u.Username).Return(usr, nil)
 	m.On("LookupID", u.UID).Return(usr, nil)
 	m.On("AddUser", u.Username, options).Return(nil)
-	status, err := u.Apply(fakerenderer.New())
+	status, err := u.Apply()
 
 	m.AssertNotCalled(t, "AddUser", u.Username, options)
 	assert.EqualError(t, err, fmt.Sprintf("will not attempt add: user %s with uid %s", u.Username, u.UID))
@@ -618,7 +618,7 @@ func TestApplyAbsentNoUidDeleteUser(t *testing.T) {
 
 	m.On("Lookup", u.Username).Return(usr, nil)
 	m.On("DelUser", u.Username).Return(nil)
-	status, err := u.Apply(fakerenderer.New())
+	status, err := u.Apply()
 
 	m.AssertCalled(t, "DelUser", u.Username)
 	assert.NoError(t, err)
@@ -638,7 +638,7 @@ func TestApplyAbsentNoUidDeleteUserError(t *testing.T) {
 
 	m.On("Lookup", u.Username).Return(usr, nil)
 	m.On("DelUser", u.Username).Return(fmt.Errorf(""))
-	status, err := u.Apply(fakerenderer.New())
+	status, err := u.Apply()
 
 	m.AssertCalled(t, "DelUser", u.Username)
 	assert.EqualError(t, err, fmt.Sprintf(""))
@@ -659,7 +659,7 @@ func TestApplyAbsentNoUidNotDeleted(t *testing.T) {
 
 	m.On("Lookup", u.Username).Return(usr, os.UnknownUserError(""))
 	m.On("DelUser", u.Username).Return(nil)
-	status, err := u.Apply(fakerenderer.New())
+	status, err := u.Apply()
 
 	m.AssertNotCalled(t, "DelUser", u.Username)
 	assert.EqualError(t, err, fmt.Sprintf("will not attempt delete: user %s", u.Username))
@@ -682,7 +682,7 @@ func TestApplyAbsentWithUidDeleteUser(t *testing.T) {
 	m.On("Lookup", u.Username).Return(usr, nil)
 	m.On("LookupID", u.UID).Return(usr, nil)
 	m.On("DelUser", u.Username).Return(nil)
-	status, err := u.Apply(fakerenderer.New())
+	status, err := u.Apply()
 
 	m.AssertCalled(t, "DelUser", u.Username)
 	assert.NoError(t, err)
@@ -705,7 +705,7 @@ func TestApplyAbsentWithUidDeleteUserError(t *testing.T) {
 	m.On("Lookup", u.Username).Return(usr, nil)
 	m.On("LookupID", u.UID).Return(usr, nil)
 	m.On("DelUser", u.Username).Return(fmt.Errorf(""))
-	status, err := u.Apply(fakerenderer.New())
+	status, err := u.Apply()
 
 	m.AssertCalled(t, "DelUser", u.Username)
 	assert.EqualError(t, err, fmt.Sprintf(""))
@@ -729,7 +729,7 @@ func TestApplyAbsentWithUidNotDeleted(t *testing.T) {
 	m.On("Lookup", u.Username).Return(usr, os.UnknownUserError(""))
 	m.On("LookupID", u.UID).Return(usr, nil)
 	m.On("DelUser", u.Username).Return(nil)
-	status, err := u.Apply(fakerenderer.New())
+	status, err := u.Apply()
 
 	m.AssertNotCalled(t, "DelUser", u.Username)
 	assert.EqualError(t, err, fmt.Sprintf("will not attempt delete: user %s with uid %s", u.Username, u.UID))
@@ -754,7 +754,7 @@ func TestApplyStateUnknown(t *testing.T) {
 	m.On("LookupID", u.UID).Return(usr, nil)
 	m.On("AddUser", u.Username, mock.Anything).Return(nil)
 	m.On("DelUser", u.Username).Return(nil)
-	_, err := u.Apply(fakerenderer.New())
+	_, err := u.Apply()
 
 	m.AssertNotCalled(t, "AddUser", u.Username, options)
 	m.AssertNotCalled(t, "DelUser", u.Username)


### PR DESCRIPTION
Implementing something that uses Status is now a lot simpler. I merged `WillChange` and `Level` (nee `WarningLevel`), made `FailingDeps` private, and straight-up removed `Status`. `HasChanges` is now calculated from the level and the diffs.

Fixes #237
Fixes #240