### PR TITLE
cmd: don't set local token if only a client

### DIFF
--- a/cmd/rpc.go
+++ b/cmd/rpc.go
@@ -176,7 +176,7 @@ func maybeSetToken() {
 		return
 	}
 
-	if getToken() == "" {
+	if getToken() == "" && getLocal() {
 		viper.Set(rpcTokenFlagName, uuid.NewV4().String())
 		log.WithField("token", getToken()).Warn("setting session-local token")
 	}
@@ -184,6 +184,7 @@ func maybeSetToken() {
 
 // More getters
 
+func setLocal(local bool)  { viper.Set(rpcLocalAddrName, local) }
 func getLocal() bool       { return viper.GetBool(rpcLocalAddrName) }
 func getRPCAddr() string   { return viper.GetString(rpcAddrFlagName) }
 func getLocalAddr() string { return viper.GetString(rpcLocalAddrName) }

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -57,6 +57,8 @@ var serverCmd = &cobra.Command{
 		var running sync.WaitGroup
 		running.Add(2)
 
+		setLocal(true) // so we generate a token
+
 		// set up our client and server security options
 		maybeSetToken()
 


### PR DESCRIPTION
Fixes #247