### PR TITLE
map keys are considered "strings" in parse.Node

### DIFF
--- a/parse/node.go
+++ b/parse/node.go
@@ -181,7 +181,8 @@ func (n *Node) GetStrings() (vals []string, err error) {
 			}
 
 		case map[string]interface{}:
-			for _, value := range val.(map[string]interface{}) {
+			for key, value := range val.(map[string]interface{}) {
+				toConsider = append(toConsider, key)
 				toConsider = append(toConsider, value)
 			}
 

--- a/parse/node_test.go
+++ b/parse/node_test.go
@@ -240,6 +240,8 @@ module x y {
 	assert.Equal(t, []string{"fst", "snd"}, vals)
 }
 
+// Handle the special case of a node with a map to ensure the keys are also
+// considered valid strings
 func TestNodeGetStringsWithMap(t *testing.T) {
 	t.Parallel()
 	node, err := fromString(`

--- a/parse/node_test.go
+++ b/parse/node_test.go
@@ -240,8 +240,8 @@ module x y {
 	assert.Equal(t, []string{"fst", "snd"}, vals)
 }
 
-// Handle the special case of a node with a map to ensure the keys are also
-// considered valid strings
+// TestNodeGetStringsWithMap will test the special case of a node with a map to
+// ensure the keys are also considered valid strings
 func TestNodeGetStringsWithMap(t *testing.T) {
 	t.Parallel()
 	node, err := fromString(`

--- a/parse/node_test.go
+++ b/parse/node_test.go
@@ -227,8 +227,8 @@ func TestNodeGetStrings(t *testing.T) {
 
 	node, err := fromString(`
 module x y {
-  fst = "fst"
-  snd = "snd"
+	fst = "fst"
+	snd = "snd"
 }
 `)
 	require.NoError(t, err)
@@ -238,4 +238,25 @@ module x y {
 
 	sort.Strings(vals)
 	assert.Equal(t, []string{"fst", "snd"}, vals)
+}
+
+func TestNodeGetStringsWithMap(t *testing.T) {
+	t.Parallel()
+	node, err := fromString(`
+module x y {
+	aMap {
+		"key" = "value"
+		nestedMap {
+			"nestedKey1" = "nestedValue1"
+		}
+	}
+}
+`)
+	require.NoError(t, err)
+
+	vals, err := node.GetStrings()
+	assert.NoError(t, err)
+
+	sort.Strings(vals)
+	assert.Equal(t, []string{"key", "nestedKey1", "nestedMap", "nestedValue1", "value"}, vals)
 }


### PR DESCRIPTION
fixes #313