### PR TITLE
Use text/tabwriter to align human output

### DIFF
--- a/prettyprinters/human/human.go
+++ b/prettyprinters/human/human.go
@@ -139,7 +139,7 @@ func (p *Printer) DrawNode(g *graph.Graph, id string) (pp.Renderable, error) {
 		return pp.HiddenString(), err
 	}
 
-	tabWriter := tabwriter.NewWriter(&out, 4, 4, 4, ' ', tabwriter.Debug)
+	tabWriter := tabwriter.NewWriter(&out, 1, 1, 1, ' ', 0)
 	_, err = tabWriter.Write(intermediate.Bytes())
 
 	return &out, err
@@ -173,7 +173,8 @@ func (p *Printer) diff(before, after string) (string, error) {
 	// remember when modifying these that diff is responsible for leading
 	// whitespace
 	if !strings.Contains(strings.TrimSpace(before), "\n") && !strings.Contains(strings.TrimSpace(after), "\n") {
-		return fmt.Sprintf("%q\t=>\t%q", strings.TrimSpace(before), strings.TrimSpace(after)), nil
+		sprintf := []string{"%q\t", "\x1b[1m", "=>", "\x1b[22m", "\t%q"}
+		return fmt.Sprintf(strings.Join(sprintf, ""), strings.TrimSpace(before), strings.TrimSpace(after)), nil
 	}
 
 	tmpl, err := p.template(`before:

--- a/prettyprinters/human/human.go
+++ b/prettyprinters/human/human.go
@@ -139,7 +139,7 @@ func (p *Printer) DrawNode(g *graph.Graph, id string) (pp.Renderable, error) {
 		return pp.HiddenString(), err
 	}
 
-	tabWriter := tabwriter.NewWriter(&out, 8, 8, 0, ' ', 0)
+	tabWriter := tabwriter.NewWriter(&out, 4, 4, 4, ' ', tabwriter.Debug)
 	_, err = tabWriter.Write(intermediate.Bytes())
 
 	return &out, err
@@ -173,7 +173,7 @@ func (p *Printer) diff(before, after string) (string, error) {
 	// remember when modifying these that diff is responsible for leading
 	// whitespace
 	if !strings.Contains(strings.TrimSpace(before), "\n") && !strings.Contains(strings.TrimSpace(after), "\n") {
-		return fmt.Sprintf(" %q => %q", strings.TrimSpace(before), strings.TrimSpace(after)), nil
+		return fmt.Sprintf("%q\t=>\t%q", strings.TrimSpace(before), strings.TrimSpace(after)), nil
 	}
 
 	tmpl, err := p.template(`before:

--- a/prettyprinters/human/human.go
+++ b/prettyprinters/human/human.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"text/tabwriter"
 	"text/template"
 
 	"github.com/asteris-llc/converge/graph"
@@ -124,7 +125,7 @@ func (p *Printer) DrawNode(g *graph.Graph, id string) (pp.Renderable, error) {
 	Has Changes: {{if .HasChanges}}{{yellow "yes"}}{{else}}no{{end}}
 	Changes:
 		{{- range $key, $values := .Changes}}
-		{{cyan $key}}:{{diff ($values.Original) ($values.Current)}}
+		{{cyan $key}}:	{{diff ($values.Original) ($values.Current)}}
 		{{- else}} No changes {{- end}}
 
 `)
@@ -132,8 +133,14 @@ func (p *Printer) DrawNode(g *graph.Graph, id string) (pp.Renderable, error) {
 		return pp.HiddenString(), err
 	}
 
-	var out bytes.Buffer
-	err = tmpl.Execute(&out, &printerNode{ID: id, Printable: printable})
+	var intermediate, out bytes.Buffer
+	err = tmpl.Execute(&intermediate, &printerNode{ID: id, Printable: printable})
+	if err != nil {
+		return pp.HiddenString(), err
+	}
+
+	tabWriter := tabwriter.NewWriter(&out, 8, 8, 0, ' ', 0)
+	_, err = tabWriter.Write(intermediate.Bytes())
 
 	return &out, err
 }

--- a/prettyprinters/human/human.go
+++ b/prettyprinters/human/human.go
@@ -174,7 +174,7 @@ func (p *Printer) diff(before, after string) (string, error) {
 	// remember when modifying these that diff is responsible for leading
 	// whitespace
 	if !strings.Contains(strings.TrimSpace(before), "\n") && !strings.Contains(strings.TrimSpace(after), "\n") {
-		return fmt.Sprintf("%q\t=>\t%q", strings.TrimSpace(before), strings.TrimSpace(after)), nil
+		return fmt.Sprintf("%q\t%s\t%q", strings.TrimSpace(before), funcs["bold"].(func(string) string)("=>"), strings.TrimSpace(after)), nil
 	}
 
 	tmpl, err := p.template(`before:

--- a/prettyprinters/human/human.go
+++ b/prettyprinters/human/human.go
@@ -52,6 +52,7 @@ func NewFiltered(f FilterFunc) *Printer {
 // InitColors initializes the colors used by the human printer
 func (p *Printer) InitColors() {
 	reset := "\x1b[0m"
+	p.funcsMapWrite("bold", p.styled(func(in string) string { return "\x1b[1m" + in + reset }))
 	p.funcsMapWrite("black", p.styled(func(in string) string { return "\x1b[30m" + in + reset }))
 	p.funcsMapWrite("red", p.styled(func(in string) string { return "\x1b[31m" + in + reset }))
 	p.funcsMapWrite("green", p.styled(func(in string) string { return "\x1b[32m" + in + reset }))
@@ -125,7 +126,7 @@ func (p *Printer) DrawNode(g *graph.Graph, id string) (pp.Renderable, error) {
 	Has Changes: {{if .HasChanges}}{{yellow "yes"}}{{else}}no{{end}}
 	Changes:
 		{{- range $key, $values := .Changes}}
-		{{cyan $key}}:	{{diff ($values.Original) ($values.Current)}}
+		{{cyan $key}}:	{{diff ($values.Original) ($values.Current) | bold}}
 		{{- else}} No changes {{- end}}
 
 `)
@@ -173,8 +174,7 @@ func (p *Printer) diff(before, after string) (string, error) {
 	// remember when modifying these that diff is responsible for leading
 	// whitespace
 	if !strings.Contains(strings.TrimSpace(before), "\n") && !strings.Contains(strings.TrimSpace(after), "\n") {
-		sprintf := []string{"%q\t", "\x1b[1m", "=>", "\x1b[22m", "\t%q"}
-		return fmt.Sprintf(strings.Join(sprintf, ""), strings.TrimSpace(before), strings.TrimSpace(after)), nil
+		return fmt.Sprintf("%q\t=>\t%q", strings.TrimSpace(before), strings.TrimSpace(after)), nil
 	}
 
 	tmpl, err := p.template(`before:

--- a/prettyprinters/human/human_test.go
+++ b/prettyprinters/human/human_test.go
@@ -115,7 +115,7 @@ func TestDrawNodeNoChanges(t *testing.T) {
 	testDrawNodes(
 		t,
 		Printable{},
-		"root:\n        Messages:\n        Has Changes: no\n        Changes: No changes\n\n",
+		"root:\n Messages:\n Has Changes: no\n Changes: No changes\n\n",
 	)
 }
 
@@ -179,7 +179,7 @@ func TestDrawNodeChanges(t *testing.T) {
 	testDrawNodes(
 		t,
 		Printable{"a": "b"},
-		"root:\n        Messages:\n        Has Changes: yes\n        Changes:\n                a:       \"\" => \"b\"\n\n",
+		"root:\n Messages:\n Has Changes: yes\n Changes:\n  a: \"\" \x1b[1m=>\x1b[22m \"b\"\n\n",
 	)
 }
 
@@ -197,7 +197,7 @@ func TestDrawNodeError(t *testing.T) {
 	testDrawNodes(
 		t,
 		Printable{"error": "x"},
-		"root:\n        Error: x\n        Messages:\n        Has Changes: yes\n        Changes:\n                error:   \"\" => \"x\"\n\n",
+		"root:\n Error: x\n Messages:\n Has Changes: yes\n Changes:\n  error: \"\" \x1b[1m=>\x1b[22m \"x\"\n\n",
 	)
 }
 

--- a/prettyprinters/human/human_test.go
+++ b/prettyprinters/human/human_test.go
@@ -179,7 +179,7 @@ func TestDrawNodeChanges(t *testing.T) {
 	testDrawNodes(
 		t,
 		Printable{"a": "b"},
-		"root:\n Messages:\n Has Changes: yes\n Changes:\n  a: \"\" \x1b[1m=>\x1b[22m \"b\"\n\n",
+		"root:\n Messages:\n Has Changes: yes\n Changes:\n  a: \"\" => \"b\"\n\n",
 	)
 }
 
@@ -197,7 +197,7 @@ func TestDrawNodeError(t *testing.T) {
 	testDrawNodes(
 		t,
 		Printable{"error": "x"},
-		"root:\n Error: x\n Messages:\n Has Changes: yes\n Changes:\n  error: \"\" \x1b[1m=>\x1b[22m \"x\"\n\n",
+		"root:\n Error: x\n Messages:\n Has Changes: yes\n Changes:\n  error: \"\" => \"x\"\n\n",
 	)
 }
 

--- a/prettyprinters/human/human_test.go
+++ b/prettyprinters/human/human_test.go
@@ -115,7 +115,7 @@ func TestDrawNodeNoChanges(t *testing.T) {
 	testDrawNodes(
 		t,
 		Printable{},
-		"root:\n\tMessages:\n\tHas Changes: no\n\tChanges: No changes\n\n",
+		"root:\n        Messages:\n        Has Changes: no\n        Changes: No changes\n\n",
 	)
 }
 
@@ -179,7 +179,7 @@ func TestDrawNodeChanges(t *testing.T) {
 	testDrawNodes(
 		t,
 		Printable{"a": "b"},
-		"root:\n\tMessages:\n\tHas Changes: yes\n\tChanges:\n\t\ta: \"\" => \"b\"\n\n",
+		"root:\n        Messages:\n        Has Changes: yes\n        Changes:\n                a:       \"\" => \"b\"\n\n",
 	)
 }
 
@@ -197,7 +197,7 @@ func TestDrawNodeError(t *testing.T) {
 	testDrawNodes(
 		t,
 		Printable{"error": "x"},
-		"root:\n\tError: x\n\tMessages:\n\tHas Changes: yes\n\tChanges:\n\t\terror: \"\" => \"x\"\n\n",
+		"root:\n        Error: x\n        Messages:\n        Has Changes: yes\n        Changes:\n                error:   \"\" => \"x\"\n\n",
 	)
 }
 


### PR DESCRIPTION
This commit adds the text/tabwriter package to the human prettyprinter
package, and updates test case inputs. This aligns values based on a new
tab inserted to the right of the colon.

Fixes #244