### PR TITLE
Handle preparer fields where zero is valid

### DIFF
--- a/resource/file/mode/mode.go
+++ b/resource/file/mode/mode.go
@@ -36,11 +36,13 @@ func (t *Mode) Check(resource.Renderer) (resource.TaskStatus, error) {
 	if os.IsNotExist(err) {
 		diffs[t.Destination] = &FileModeDiff{Expected: t.Mode}
 		status := fmt.Sprintf("%q does not exist", t.Destination)
-		return &resource.Status{
+		stat := &resource.Status{
 			Level:       resource.StatusFatal,
 			Differences: diffs,
 			Output:      []string{status},
-		}, nil
+		}
+		stat.SetError(fmt.Errorf("cannot set mode for file that does not exist"))
+		return stat, nil
 	} else if err != nil {
 		return nil, err
 	}
@@ -57,7 +59,7 @@ func (t *Mode) Check(resource.Renderer) (resource.TaskStatus, error) {
 		Level:       warningLevel,
 		Differences: diffs,
 		Output: []string{
-			fmt.Sprintf("%q exist", t.Destination),
+			fmt.Sprintf("%q exists", t.Destination),
 			status,
 		},
 	}

--- a/resource/file/mode/mode_test.go
+++ b/resource/file/mode/mode_test.go
@@ -27,12 +27,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestTemplateInterface tests whether file mode is properly implemented
 func TestTemplateInterface(t *testing.T) {
 	t.Parallel()
 
 	assert.Implements(t, (*resource.Task)(nil), new(mode.Mode))
 }
 
+// TestCheck tests Check() for file mode
 func TestCheck(t *testing.T) {
 	tmpfile, err := ioutil.TempFile("", "mode_test")
 	assert.NoError(t, os.Chmod(tmpfile.Name(), 0600))
@@ -47,6 +49,7 @@ func TestCheck(t *testing.T) {
 	assert.True(t, status.HasChanges())
 }
 
+// TestApply tests Apply() for file mode
 func TestApply(t *testing.T) {
 
 	tmpfile, err := ioutil.TempFile("", "mode_test")

--- a/resource/file/mode/preparer.go
+++ b/resource/file/mode/preparer.go
@@ -15,7 +15,6 @@
 package mode
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/asteris-llc/converge/load/registry"
@@ -29,21 +28,17 @@ type Preparer struct {
 	// Destination specifies which file will be modified by this resource. The
 	// file must exist on the system (for example, having been created with
 	// `file.content`.)
-	Destination string `hcl:"destination"`
+	Destination string `hcl:"destination" required:"true"`
 
 	// Mode is the mode of the file, specified in octal.
-	Mode uint32 `hcl:"mode" base:"8"`
+	Mode *uint32 `hcl:"mode" base:"8" required:"true"`
 }
 
 // Prepare this resource for use
 func (p *Preparer) Prepare(render resource.Renderer) (resource.Task, error) {
-	if p.Mode == 0 {
-		return nil, fmt.Errorf("task requires a \"mode\" parameter")
-	}
-
 	modeTask := &Mode{
 		Destination: p.Destination,
-		Mode:        os.FileMode(p.Mode),
+		Mode:        os.FileMode(*p.Mode),
 	}
 	return modeTask, modeTask.Validate()
 }

--- a/resource/file/mode/preparer_test.go
+++ b/resource/file/mode/preparer_test.go
@@ -15,7 +15,6 @@
 package mode_test
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/asteris-llc/converge/helpers/fakerenderer"
@@ -24,32 +23,19 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// TestPreparerInterface tests that file mode has been properly implemented
 func TestPreparerInterface(t *testing.T) {
 	t.Parallel()
 
 	assert.Implements(t, (*resource.Resource)(nil), new(mode.Preparer))
 }
 
-func TestVaildPreparer(t *testing.T) {
+// TestValidPreparer tests file mode Prepare()
+func TestValidPreparer(t *testing.T) {
 	t.Parallel()
+	var testMode uint32 = 777
 	fr := fakerenderer.FakeRenderer{}
-	prep := mode.Preparer{Destination: "path/to/file", Mode: 777}
+	prep := mode.Preparer{Destination: "path/to/file", Mode: &testMode}
 	_, err := prep.Prepare(&fr)
 	assert.NoError(t, err)
-}
-
-func TestInVaildPreparerNoDestination(t *testing.T) {
-	t.Parallel()
-	fr := fakerenderer.FakeRenderer{}
-	prep := mode.Preparer{Mode: 777}
-	_, err := prep.Prepare(&fr)
-	assert.EqualError(t, err, fmt.Sprintf("task requires a \"destination\" parameter"))
-}
-
-func TestInVaildPreparerNoMode(t *testing.T) {
-	t.Parallel()
-	fr := fakerenderer.FakeRenderer{}
-	prep := mode.Preparer{Destination: "path/to/file"}
-	_, err := prep.Prepare(&fr)
-	assert.EqualError(t, err, fmt.Sprintf("task requires a \"mode\" parameter"))
 }

--- a/resource/group/preparer.go
+++ b/resource/group/preparer.go
@@ -27,7 +27,7 @@ import (
 // Group renders group data
 type Preparer struct {
 	// Gid is the group gid.
-	GID uint32 `hcl:"gid"`
+	GID *uint32 `hcl:"gid"`
 
 	// Name is the group name.
 	Name string `hcl:"name" required:"true"`
@@ -38,7 +38,7 @@ type Preparer struct {
 
 // Prepare a new task
 func (p *Preparer) Prepare(render resource.Renderer) (resource.Task, error) {
-	if p.GID == math.MaxUint32 {
+	if p.GID != nil && *p.GID == math.MaxUint32 {
 		// the maximum gid on linux is MaxUint32 - 1
 		return nil, fmt.Errorf("group \"gid\" parameter out of range")
 	}
@@ -49,8 +49,11 @@ func (p *Preparer) Prepare(render resource.Renderer) (resource.Task, error) {
 
 	grp := NewGroup(new(System))
 	grp.Name = p.Name
-	grp.GID = fmt.Sprintf("%v", p.GID)
 	grp.State = p.State
+
+	if p.GID != nil {
+		grp.GID = fmt.Sprintf("%v", *p.GID)
+	}
 
 	return grp, nil
 }

--- a/resource/group/preparer_test.go
+++ b/resource/group/preparer_test.go
@@ -37,17 +37,21 @@ func TestPrepare(t *testing.T) {
 	t.Parallel()
 
 	fr := fakerenderer.FakeRenderer{}
+	var invalidGID = uint32(math.MaxUint32)
+	var maxGID = uint32(math.MaxUint32 - 1)
+	var minGID uint32
+	var testGID uint32 = 123
 
 	t.Run("valid", func(t *testing.T) {
 		t.Run("all parameters", func(t *testing.T) {
-			p := group.Preparer{GID: 123, Name: "test", State: group.StateAbsent}
+			p := group.Preparer{GID: &testGID, Name: "test", State: group.StateAbsent}
 			_, err := p.Prepare(&fr)
 
 			assert.NoError(t, err)
 		})
 
 		t.Run("no state parameter", func(t *testing.T) {
-			p := group.Preparer{GID: 123, Name: "test"}
+			p := group.Preparer{GID: &testGID, Name: "test"}
 			_, err := p.Prepare(&fr)
 
 			assert.NoError(t, err)
@@ -60,8 +64,15 @@ func TestPrepare(t *testing.T) {
 			assert.NoError(t, err)
 		})
 
+		t.Run("min allowable gid", func(t *testing.T) {
+			p := group.Preparer{GID: &minGID, Name: "test"}
+			_, err := p.Prepare(&fr)
+
+			assert.NoError(t, err)
+		})
+
 		t.Run("max allowable gid", func(t *testing.T) {
-			p := group.Preparer{GID: math.MaxUint32 - 1, Name: "test"}
+			p := group.Preparer{GID: &maxGID, Name: "test"}
 			_, err := p.Prepare(&fr)
 
 			assert.NoError(t, err)
@@ -70,7 +81,7 @@ func TestPrepare(t *testing.T) {
 
 	t.Run("invalid", func(t *testing.T) {
 		t.Run("gid out of range", func(t *testing.T) {
-			p := group.Preparer{GID: math.MaxUint32, Name: "test"}
+			p := group.Preparer{GID: &invalidGID, Name: "test"}
 			_, err := p.Prepare(&fr)
 
 			assert.EqualError(t, err, fmt.Sprintf("group \"gid\" parameter out of range"))

--- a/resource/user/preparer.go
+++ b/resource/user/preparer.go
@@ -30,7 +30,7 @@ type Preparer struct {
 	Username string `hcl:"username" required:"true"`
 
 	// UID is the user ID.
-	UID uint32 `hcl:"uid"`
+	UID *uint32 `hcl:"uid"`
 
 	// GroupName is the primary group for user and must already exist.
 	// Only one of GID or Groupname may be indicated.
@@ -38,7 +38,7 @@ type Preparer struct {
 
 	// Gid is the primary group ID for user and must refer to an existing group.
 	// Only one of GID or Groupname may be indicated.
-	GID uint32 `hcl:"gid" mutually_exclusive:"gid,groupname"`
+	GID *uint32 `hcl:"gid" mutually_exclusive:"gid,groupname"`
 
 	// Name is the user description.
 	Name string `hcl:"name"`
@@ -53,12 +53,12 @@ type Preparer struct {
 
 // Prepare a new task
 func (p *Preparer) Prepare(render resource.Renderer) (resource.Task, error) {
-	if p.UID == math.MaxUint32 {
+	if p.UID != nil && *p.UID == math.MaxUint32 {
 		// the maximum uid on linux is MaxUint32 - 1
 		return nil, fmt.Errorf("user \"uid\" parameter out of range")
 	}
 
-	if p.GID == math.MaxUint32 {
+	if p.GID != nil && *p.GID == math.MaxUint32 {
 		// the maximum gid on linux is MaxUint32 - 1
 		return nil, fmt.Errorf("user \"gid\" parameter out of range")
 	}
@@ -69,12 +69,18 @@ func (p *Preparer) Prepare(render resource.Renderer) (resource.Task, error) {
 
 	usr := NewUser(new(System))
 	usr.Username = p.Username
-	usr.UID = fmt.Sprintf("%v", p.UID)
 	usr.GroupName = p.GroupName
-	usr.GID = fmt.Sprintf("%v", p.GID)
 	usr.Name = p.Name
 	usr.HomeDir = p.HomeDir
 	usr.State = p.State
+
+	if p.UID != nil {
+		usr.UID = fmt.Sprintf("%v", *p.UID)
+	}
+
+	if p.GID != nil {
+		usr.GID = fmt.Sprintf("%v", *p.GID)
+	}
 
 	return usr, nil
 }


### PR DESCRIPTION
Uses #339 to handle module parameters in which zero is a valid value.
Updated the following modules:
- file.mode
- user.group
- user.user