### PR TITLE
FIX local command flag added to example

### DIFF
--- a/docs_source/content/getting-started.md
+++ b/docs_source/content/getting-started.md
@@ -194,7 +194,7 @@ module "helloWorld.hcl" "hello" {
 }
 ```
 
-Now try running `converge plan helloYou.hcl`. The same thing happens as if you
+Now try running `converge plan --local helloYou.hcl`. The same thing happens as if you
 had called the module yourself!
 
 But once again, how does this effect our graph? You remember before that we had


### PR DESCRIPTION
As discussed in Slack, just a simple fix in the getting started page. The user is running locally, so you need the `--local` flag in the example command, just like all the others are on the page, to allow it to run without error.

```
- Now try running `converge plan helloYou.hcl`. The same thing happens as if you had called the module yourself!
+ Now try running `converge plan --local helloYou.hcl`. The same thing happens as if you had called the module yourself!
```