### PR TITLE
use a container for CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ runs tasks in parallel.
     - [Development](#development)
         - [Tools](#tools)
         - [RPC](#rpc)
+        - [Continuous Integration and Testing](#continuous-integration-and-testing)
     - [License](#license)
 
 <!-- markdown-toc end -->
@@ -92,6 +93,22 @@ You'll need:
   or above.
 - The go protoc plugin: `go get -a github.com/golang/protobuf/protoc-gen-go`
 - The grpc gateway plugin(s): `go get -u github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger`
+
+### Continuous Integration and Testing
+
+We use Wercker for CI with a custom base image. The Dockerfile for that image
+can be found at `/ci/Dockerfile` in the root of the project, and is pushed as
+`asteris/converge-ci`. You can do test Converge in the container with the
+following invocation:
+
+```sh
+docker run -i \
+           -t \
+           --rm \
+           --volume $(pwd):/go/src/github.com/asteris-llc/converge \
+           asteris/converge-ci \
+           /bin/bash -c 'cd /go/src/github.com/asteris-llc/converge; make test'
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ You'll need:
 
 We use Wercker for CI with a custom base image. The Dockerfile for that image
 can be found at `/ci/Dockerfile` in the root of the project, and is pushed as
-`asteris/converge-ci`. You can do test Converge in the container with the
+`asteris/converge-ci`. You can test Converge in the container with the
 following invocation:
 
 ```sh

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,0 +1,19 @@
+FROM golang:1.7
+
+# update everything
+RUN apt-get update
+
+# install graphviz
+RUN apt-get install -y graphviz
+
+# install protoc
+RUN apt-get install -y unzip && \
+    wget https://github.com/google/protobuf/releases/download/v3.0.0/protoc-3.0.0-linux-x86_64.zip && \
+    unzip protoc-3.0.0-linux-x86_64.zip && \
+    mv bin/* /usr/bin/ && \
+    mv include/google /usr/include/google && \
+    go get -v github.com/golang/protobuf/protoc-gen-go github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger && \
+    apt-get purge -y unzip
+
+WORKDIR /go
+CMD /bin/bash

--- a/docs_source/content/index.md
+++ b/docs_source/content/index.md
@@ -84,6 +84,21 @@ You'll need:
 - The go protoc plugin: `go get -a github.com/golang/protobuf/protoc-gen-go`
 - The grpc gateway plugin(s): `go get -u github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger`
 
+### Continuous Integration and Testing
+
+We use Wercker for CI with a custom base image. The Dockerfile for that image
+can be found at `/ci/Dockerfile` in the root of the project, and is pushed as
+`asteris/converge-ci`. You can do test Converge in the container with the
+following invocation:
+
+```sh
+docker run -i \
+           -t \
+           --rm \
+           --volume $(pwd):/go/src/github.com/asteris-llc/converge \
+           asteris/converge-ci \
+           /bin/bash -c 'cd /go/src/github.com/asteris-llc/converge; make test'
+```
 ## License
 
 Converge is licensed under the Apache 2.0 license. See [LICENSE](LICENSE) for

--- a/docs_source/content/index.md
+++ b/docs_source/content/index.md
@@ -88,7 +88,7 @@ You'll need:
 
 We use Wercker for CI with a custom base image. The Dockerfile for that image
 can be found at `/ci/Dockerfile` in the root of the project, and is pushed as
-`asteris/converge-ci`. You can do test Converge in the container with the
+`asteris/converge-ci`. You can test Converge in the container with the
 following invocation:
 
 ```sh

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,28 +1,9 @@
-box: golang
-
 build:
+  box: asteris/converge-ci
   steps:
-    # Sets the go workspace and places you package
+    # Sets the go workspace and places your package
     # at the right place in the workspace tree
     - setup-go-workspace
-
-    # install graphviz
-    - script:
-        name: install graphviz
-        code: |
-          apt-get update
-          apt-get install -y graphviz
-
-    # install protoc
-    - script:
-        name: install protoc
-        code: |
-          apt-get install -y unzip
-          wget https://github.com/google/protobuf/releases/download/v3.0.0/protoc-3.0.0-linux-x86_64.zip
-          unzip protoc-3.0.0-linux-x86_64.zip
-          mv bin/* /usr/bin/
-          mv include/google /usr/include/google
-          go get -v github.com/golang/protobuf/protoc-gen-go github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger
 
     # Test the project
     - script:


### PR DESCRIPTION
We had a bunch of dependencies we were installing before CI would begin. No need to do those all the time. Let's just use a custom container. Thanks Wercker!