### PR TITLE
Update user status level and errors, add checks in Apply for group

### DIFF
--- a/resource/user/user.go
+++ b/resource/user/user.go
@@ -93,7 +93,7 @@ func (u *User) Check(resource.Renderer) (resource.TaskStatus, error) {
 	status := &resource.Status{}
 
 	if nameErr == ErrUnsupported {
-		status.Level = resource.StatusFatal
+		status.RaiseLevel(resource.StatusFatal)
 		return status, ErrUnsupported
 	}
 
@@ -111,19 +111,19 @@ func (u *User) Check(resource.Renderer) (resource.TaskStatus, error) {
 				case u.GroupName != "":
 					_, err := u.system.LookupGroup(u.GroupName)
 					if err != nil {
-						status.Level = resource.StatusCantChange
+						status.RaiseLevel(resource.StatusCantChange)
 						status.Output = append(status.Output, fmt.Sprintf("group %s does not exist", u.GroupName))
 						return status, fmt.Errorf("cannot add user %s", u.Username)
 					}
 				case u.GID != "":
 					_, err := u.system.LookupGroupID(u.GID)
 					if err != nil {
-						status.Level = resource.StatusCantChange
+						status.RaiseLevel(resource.StatusCantChange)
 						status.Output = append(status.Output, fmt.Sprintf("group gid %s does not exist", u.GID))
 						return status, fmt.Errorf("cannot add user %s", u.Username)
 					}
 				}
-				status.Level = resource.StatusWillChange
+				status.RaiseLevel(resource.StatusWillChange)
 				status.Output = append(status.Output, "user does not exist")
 				status.AddDifference("user", string(StateAbsent), fmt.Sprintf("user %s", u.Username), "")
 			}
@@ -137,35 +137,35 @@ func (u *User) Check(resource.Renderer) (resource.TaskStatus, error) {
 				case u.GroupName != "":
 					_, err := u.system.LookupGroup(u.GroupName)
 					if err != nil {
-						status.Level = resource.StatusCantChange
+						status.RaiseLevel(resource.StatusCantChange)
 						status.Output = append(status.Output, fmt.Sprintf("group %s does not exist", u.GroupName))
 						return status, fmt.Errorf("cannot add user %s with uid %s", u.Username, u.UID)
 					}
 				case u.GID != "":
 					_, err := u.system.LookupGroupID(u.GID)
 					if err != nil {
-						status.Level = resource.StatusCantChange
+						status.RaiseLevel(resource.StatusCantChange)
 						status.Output = append(status.Output, fmt.Sprintf("group gid %s does not exist", u.GID))
 						return status, fmt.Errorf("cannot add user %s with uid %s", u.Username, u.UID)
 					}
 				}
-				status.Level = resource.StatusWillChange
+				status.RaiseLevel(resource.StatusWillChange)
 				status.Output = append(status.Output, "user name and uid do not exist")
 				status.AddDifference("user", string(StateAbsent), fmt.Sprintf("user %s with uid %s", u.Username, u.UID), "")
 			case nameNotFound:
-				status.Level = resource.StatusCantChange
+				status.RaiseLevel(resource.StatusCantChange)
 				status.Output = append(status.Output, fmt.Sprintf("user uid %s already exists", u.UID))
 				return status, fmt.Errorf("cannot add user %s with uid %s", u.Username, u.UID)
 			case uidNotFound:
-				status.Level = resource.StatusCantChange
+				status.RaiseLevel(resource.StatusCantChange)
 				status.Output = append(status.Output, fmt.Sprintf("user %s already exists", u.Username))
 				return status, fmt.Errorf("cannot add user %s with uid %s", u.Username, u.UID)
 			case userByName != nil && userByID != nil && userByName.Name != userByID.Name || userByName.Uid != userByID.Uid:
-				status.Level = resource.StatusCantChange
+				status.RaiseLevel(resource.StatusCantChange)
 				status.Output = append(status.Output, fmt.Sprintf("user %s and uid %s belong to different users", u.Username, u.UID))
 				return status, fmt.Errorf("cannot add user %s with uid %s", u.Username, u.UID)
 			case userByName != nil && userByID != nil && *userByName == *userByID:
-				status.Level = resource.StatusCantChange
+				status.RaiseLevel(resource.StatusCantChange)
 				status.Output = append(status.Output, fmt.Sprintf("user %s with uid %s already exists", u.Username, u.UID))
 				return status, fmt.Errorf("cannot add user %s with uid %s", u.Username, u.UID)
 			}
@@ -179,7 +179,7 @@ func (u *User) Check(resource.Renderer) (resource.TaskStatus, error) {
 			case nameNotFound:
 				status.Output = append(status.Output, fmt.Sprintf("user %s does not exist", u.Username))
 			case userByName != nil:
-				status.Level = resource.StatusWillChange
+				status.RaiseLevel(resource.StatusWillChange)
 				status.AddDifference("user", fmt.Sprintf("user %s", u.Username), string(StateAbsent), "")
 			}
 		case u.UID != "":
@@ -190,24 +190,24 @@ func (u *User) Check(resource.Renderer) (resource.TaskStatus, error) {
 			case nameNotFound && uidNotFound:
 				status.Output = append(status.Output, "user name and uid do not exist")
 			case nameNotFound:
-				status.Level = resource.StatusCantChange
+				status.RaiseLevel(resource.StatusCantChange)
 				status.Output = append(status.Output, fmt.Sprintf("user %s does not exist", u.Username))
 				return status, fmt.Errorf("cannot delete user %s with uid %s", u.Username, u.UID)
 			case uidNotFound:
-				status.Level = resource.StatusCantChange
+				status.RaiseLevel(resource.StatusCantChange)
 				status.Output = append(status.Output, fmt.Sprintf("user uid %s does not exist", u.UID))
 				return status, fmt.Errorf("cannot delete user %s with uid %s", u.Username, u.UID)
 			case userByName != nil && userByID != nil && userByName.Name != userByID.Name || userByName.Uid != userByID.Uid:
-				status.Level = resource.StatusCantChange
+				status.RaiseLevel(resource.StatusCantChange)
 				status.Output = append(status.Output, fmt.Sprintf("user %s and uid %s belong to different users", u.Username, u.UID))
 				return status, fmt.Errorf("cannot delete user %s with uid %s", u.Username, u.UID)
 			case userByName != nil && userByID != nil && *userByName == *userByID:
-				status.Level = resource.StatusWillChange
+				status.RaiseLevel(resource.StatusWillChange)
 				status.AddDifference("user", fmt.Sprintf("user %s with uid %s", u.Username, u.UID), string(StateAbsent), "")
 			}
 		}
 	default:
-		status.Level = resource.StatusFatal
+		status.RaiseLevel(resource.StatusFatal)
 		return status, fmt.Errorf("user: unrecognized state %v", u.State)
 	}
 
@@ -233,7 +233,7 @@ func (u *User) Apply() (resource.TaskStatus, error) {
 	status := &resource.Status{}
 
 	if nameErr == ErrUnsupported {
-		status.Level = resource.StatusFatal
+		status.RaiseLevel(resource.StatusFatal)
 		return status, ErrUnsupported
 	}
 
@@ -247,19 +247,19 @@ func (u *User) Apply() (resource.TaskStatus, error) {
 			case nameNotFound:
 				options, err := SetAddUserOptions(u)
 				if err != nil {
-					status.Level = resource.StatusCantChange
+					status.RaiseLevel(resource.StatusCantChange)
 					status.Output = append(status.Output, err.Error())
 					return status, fmt.Errorf("will not attempt add: user %s", u.Username)
 				}
 				err = u.system.AddUser(u.Username, options)
 				if err != nil {
-					status.Level = resource.StatusFatal
+					status.RaiseLevel(resource.StatusFatal)
 					status.Output = append(status.Output, fmt.Sprintf("error adding user %s", u.Username))
 					return status, errors.Wrap(err, "user add")
 				}
 				status.Output = append(status.Output, fmt.Sprintf("added user %s", u.Username))
 			default:
-				status.Level = resource.StatusCantChange
+				status.RaiseLevel(resource.StatusCantChange)
 				return status, fmt.Errorf("will not attempt add: user %s", u.Username)
 			}
 		case u.UID != "":
@@ -270,19 +270,19 @@ func (u *User) Apply() (resource.TaskStatus, error) {
 			case nameNotFound && uidNotFound:
 				options, err := SetAddUserOptions(u)
 				if err != nil {
-					status.Level = resource.StatusCantChange
+					status.RaiseLevel(resource.StatusCantChange)
 					status.Output = append(status.Output, err.Error())
 					return status, fmt.Errorf("will not attempt add: user %s with uid %s", u.Username, u.UID)
 				}
 				err = u.system.AddUser(u.Username, options)
 				if err != nil {
-					status.Level = resource.StatusFatal
+					status.RaiseLevel(resource.StatusFatal)
 					status.Output = append(status.Output, fmt.Sprintf("error adding user %s with uid %s", u.Username, u.UID))
 					return status, errors.Wrap(err, "user add")
 				}
 				status.Output = append(status.Output, fmt.Sprintf("added user %s with uid %s", u.Username, u.UID))
 			default:
-				status.Level = resource.StatusCantChange
+				status.RaiseLevel(resource.StatusCantChange)
 				return status, fmt.Errorf("will not attempt add: user %s with uid %s", u.Username, u.UID)
 			}
 		}
@@ -295,13 +295,13 @@ func (u *User) Apply() (resource.TaskStatus, error) {
 			case !nameNotFound && userByName != nil:
 				err := u.system.DelUser(u.Username)
 				if err != nil {
-					status.Level = resource.StatusFatal
+					status.RaiseLevel(resource.StatusFatal)
 					status.Output = append(status.Output, fmt.Sprintf("error deleting user %s", u.Username))
 					return status, errors.Wrap(err, "user delete")
 				}
 				status.Output = append(status.Output, fmt.Sprintf("deleted user %s", u.Username))
 			default:
-				status.Level = resource.StatusCantChange
+				status.RaiseLevel(resource.StatusCantChange)
 				return status, fmt.Errorf("will not attempt delete: user %s", u.Username)
 			}
 		case u.UID != "":
@@ -312,18 +312,18 @@ func (u *User) Apply() (resource.TaskStatus, error) {
 			case !nameNotFound && !uidNotFound && userByName != nil && userByID != nil && *userByName == *userByID:
 				err := u.system.DelUser(u.Username)
 				if err != nil {
-					status.Level = resource.StatusFatal
+					status.RaiseLevel(resource.StatusFatal)
 					status.Output = append(status.Output, fmt.Sprintf("error deleting user %s with uid %s", u.Username, u.UID))
 					return status, errors.Wrap(err, "user delete")
 				}
 				status.Output = append(status.Output, fmt.Sprintf("deleted user %s with uid %s", u.Username, u.UID))
 			default:
-				status.Level = resource.StatusCantChange
+				status.RaiseLevel(resource.StatusCantChange)
 				return status, fmt.Errorf("will not attempt delete: user %s with uid %s", u.Username, u.UID)
 			}
 		}
 	default:
-		status.Level = resource.StatusFatal
+		status.RaiseLevel(resource.StatusFatal)
 		return status, fmt.Errorf("user: unrecognized state %s", u.State)
 	}
 

--- a/resource/user/user.go
+++ b/resource/user/user.go
@@ -19,6 +19,7 @@ import (
 	"os/user"
 
 	"github.com/asteris-llc/converge/resource"
+	"github.com/pkg/errors"
 )
 
 // State type for User
@@ -110,16 +111,16 @@ func (u *User) Check(resource.Renderer) (resource.TaskStatus, error) {
 				case u.GroupName != "":
 					_, err := u.system.LookupGroup(u.GroupName)
 					if err != nil {
-						status.Level = resource.StatusFatal
+						status.Level = resource.StatusCantChange
 						status.Output = append(status.Output, fmt.Sprintf("group %s does not exist", u.GroupName))
-						return status, fmt.Errorf("will not add user %s", u.Username)
+						return status, fmt.Errorf("cannot add user %s", u.Username)
 					}
 				case u.GID != "":
 					_, err := u.system.LookupGroupID(u.GID)
 					if err != nil {
-						status.Level = resource.StatusFatal
+						status.Level = resource.StatusCantChange
 						status.Output = append(status.Output, fmt.Sprintf("group gid %s does not exist", u.GID))
-						return status, fmt.Errorf("will not add user %s", u.Username)
+						return status, fmt.Errorf("cannot add user %s", u.Username)
 					}
 				}
 				status.Level = resource.StatusWillChange
@@ -136,32 +137,37 @@ func (u *User) Check(resource.Renderer) (resource.TaskStatus, error) {
 				case u.GroupName != "":
 					_, err := u.system.LookupGroup(u.GroupName)
 					if err != nil {
-						status.Level = resource.StatusFatal
+						status.Level = resource.StatusCantChange
 						status.Output = append(status.Output, fmt.Sprintf("group %s does not exist", u.GroupName))
-						return status, fmt.Errorf("will not add user %s with uid %s", u.Username, u.UID)
+						return status, fmt.Errorf("cannot add user %s with uid %s", u.Username, u.UID)
 					}
 				case u.GID != "":
 					_, err := u.system.LookupGroupID(u.GID)
 					if err != nil {
-						status.Level = resource.StatusFatal
+						status.Level = resource.StatusCantChange
 						status.Output = append(status.Output, fmt.Sprintf("group gid %s does not exist", u.GID))
-						return status, fmt.Errorf("will not add user %s with uid %s", u.Username, u.UID)
+						return status, fmt.Errorf("cannot add user %s with uid %s", u.Username, u.UID)
 					}
 				}
 				status.Level = resource.StatusWillChange
 				status.Output = append(status.Output, "user name and uid do not exist")
 				status.AddDifference("user", string(StateAbsent), fmt.Sprintf("user %s with uid %s", u.Username, u.UID), "")
 			case nameNotFound:
-				status.Level = resource.StatusFatal
+				status.Level = resource.StatusCantChange
 				status.Output = append(status.Output, fmt.Sprintf("user uid %s already exists", u.UID))
+				return status, fmt.Errorf("cannot add user %s with uid %s", u.Username, u.UID)
 			case uidNotFound:
-				status.Level = resource.StatusFatal
+				status.Level = resource.StatusCantChange
 				status.Output = append(status.Output, fmt.Sprintf("user %s already exists", u.Username))
+				return status, fmt.Errorf("cannot add user %s with uid %s", u.Username, u.UID)
 			case userByName != nil && userByID != nil && userByName.Name != userByID.Name || userByName.Uid != userByID.Uid:
-				status.Level = resource.StatusFatal
+				status.Level = resource.StatusCantChange
 				status.Output = append(status.Output, fmt.Sprintf("user %s and uid %s belong to different users", u.Username, u.UID))
+				return status, fmt.Errorf("cannot add user %s with uid %s", u.Username, u.UID)
 			case userByName != nil && userByID != nil && *userByName == *userByID:
+				status.Level = resource.StatusCantChange
 				status.Output = append(status.Output, fmt.Sprintf("user %s with uid %s already exists", u.Username, u.UID))
+				return status, fmt.Errorf("cannot add user %s with uid %s", u.Username, u.UID)
 			}
 		}
 	case StateAbsent:
@@ -184,14 +190,17 @@ func (u *User) Check(resource.Renderer) (resource.TaskStatus, error) {
 			case nameNotFound && uidNotFound:
 				status.Output = append(status.Output, "user name and uid do not exist")
 			case nameNotFound:
-				status.Level = resource.StatusFatal
+				status.Level = resource.StatusCantChange
 				status.Output = append(status.Output, fmt.Sprintf("user %s does not exist", u.Username))
+				return status, fmt.Errorf("cannot delete user %s with uid %s", u.Username, u.UID)
 			case uidNotFound:
-				status.Level = resource.StatusFatal
+				status.Level = resource.StatusCantChange
 				status.Output = append(status.Output, fmt.Sprintf("user uid %s does not exist", u.UID))
+				return status, fmt.Errorf("cannot delete user %s with uid %s", u.Username, u.UID)
 			case userByName != nil && userByID != nil && userByName.Name != userByID.Name || userByName.Uid != userByID.Uid:
-				status.Level = resource.StatusFatal
+				status.Level = resource.StatusCantChange
 				status.Output = append(status.Output, fmt.Sprintf("user %s and uid %s belong to different users", u.Username, u.UID))
+				return status, fmt.Errorf("cannot delete user %s with uid %s", u.Username, u.UID)
 			case userByName != nil && userByID != nil && *userByName == *userByID:
 				status.Level = resource.StatusWillChange
 				status.AddDifference("user", fmt.Sprintf("user %s with uid %s", u.Username, u.UID), string(StateAbsent), "")
@@ -236,16 +245,21 @@ func (u *User) Apply() (resource.TaskStatus, error) {
 
 			switch {
 			case nameNotFound:
-				options := SetAddUserOptions(u)
-				err := u.system.AddUser(u.Username, options)
+				options, err := SetAddUserOptions(u)
+				if err != nil {
+					status.Level = resource.StatusCantChange
+					status.Output = append(status.Output, err.Error())
+					return status, fmt.Errorf("will not attempt add: user %s", u.Username)
+				}
+				err = u.system.AddUser(u.Username, options)
 				if err != nil {
 					status.Level = resource.StatusFatal
 					status.Output = append(status.Output, fmt.Sprintf("error adding user %s", u.Username))
-					return status, err
+					return status, errors.Wrap(err, "user add")
 				}
 				status.Output = append(status.Output, fmt.Sprintf("added user %s", u.Username))
 			default:
-				status.Level = resource.StatusFatal
+				status.Level = resource.StatusCantChange
 				return status, fmt.Errorf("will not attempt add: user %s", u.Username)
 			}
 		case u.UID != "":
@@ -254,16 +268,21 @@ func (u *User) Apply() (resource.TaskStatus, error) {
 
 			switch {
 			case nameNotFound && uidNotFound:
-				options := SetAddUserOptions(u)
-				err := u.system.AddUser(u.Username, options)
+				options, err := SetAddUserOptions(u)
+				if err != nil {
+					status.Level = resource.StatusCantChange
+					status.Output = append(status.Output, err.Error())
+					return status, fmt.Errorf("will not attempt add: user %s with uid %s", u.Username, u.UID)
+				}
+				err = u.system.AddUser(u.Username, options)
 				if err != nil {
 					status.Level = resource.StatusFatal
 					status.Output = append(status.Output, fmt.Sprintf("error adding user %s with uid %s", u.Username, u.UID))
-					return status, err
+					return status, errors.Wrap(err, "user add")
 				}
 				status.Output = append(status.Output, fmt.Sprintf("added user %s with uid %s", u.Username, u.UID))
 			default:
-				status.Level = resource.StatusFatal
+				status.Level = resource.StatusCantChange
 				return status, fmt.Errorf("will not attempt add: user %s with uid %s", u.Username, u.UID)
 			}
 		}
@@ -278,11 +297,11 @@ func (u *User) Apply() (resource.TaskStatus, error) {
 				if err != nil {
 					status.Level = resource.StatusFatal
 					status.Output = append(status.Output, fmt.Sprintf("error deleting user %s", u.Username))
-					return status, err
+					return status, errors.Wrap(err, "user delete")
 				}
 				status.Output = append(status.Output, fmt.Sprintf("deleted user %s", u.Username))
 			default:
-				status.Level = resource.StatusFatal
+				status.Level = resource.StatusCantChange
 				return status, fmt.Errorf("will not attempt delete: user %s", u.Username)
 			}
 		case u.UID != "":
@@ -295,11 +314,11 @@ func (u *User) Apply() (resource.TaskStatus, error) {
 				if err != nil {
 					status.Level = resource.StatusFatal
 					status.Output = append(status.Output, fmt.Sprintf("error deleting user %s with uid %s", u.Username, u.UID))
-					return status, err
+					return status, errors.Wrap(err, "user delete")
 				}
 				status.Output = append(status.Output, fmt.Sprintf("deleted user %s with uid %s", u.Username, u.UID))
 			default:
-				status.Level = resource.StatusFatal
+				status.Level = resource.StatusCantChange
 				return status, fmt.Errorf("will not attempt delete: user %s with uid %s", u.Username, u.UID)
 			}
 		}
@@ -313,7 +332,9 @@ func (u *User) Apply() (resource.TaskStatus, error) {
 
 // SetAddUserOptions returns a AddUserOptions struct with the options
 // specified in the configuration for adding a user
-func SetAddUserOptions(u *User) *AddUserOptions {
+// If group information is provided and the group is not found, nil and an
+// error indicating the group name or gid is not found is returned
+func SetAddUserOptions(u *User) (*AddUserOptions, error) {
 	options := new(AddUserOptions)
 
 	if u.UID != "" {
@@ -322,8 +343,16 @@ func SetAddUserOptions(u *User) *AddUserOptions {
 
 	switch {
 	case u.GroupName != "":
+		_, err := u.system.LookupGroup(u.GroupName)
+		if err != nil {
+			return nil, fmt.Errorf("group %s does not exist", u.GroupName)
+		}
 		options.Group = u.GroupName
 	case u.GID != "":
+		_, err := u.system.LookupGroupID(u.GID)
+		if err != nil {
+			return nil, fmt.Errorf("group gid %s does not exist", u.GID)
+		}
 		options.Group = u.GID
 	}
 
@@ -335,5 +364,5 @@ func SetAddUserOptions(u *User) *AddUserOptions {
 		options.Directory = u.HomeDir
 	}
 
-	return options
+	return options, nil
 }

--- a/resource/user/user_test.go
+++ b/resource/user/user_test.go
@@ -152,9 +152,8 @@ func TestCheck(t *testing.T) {
 					status, err := u.Check(fakerenderer.New())
 
 					if runtime.GOOS == "linux" {
-						assert.EqualError(t, err, fmt.Sprintf("cannot add user %s", u.Username))
+						assert.EqualError(t, err, fmt.Sprintf("cannot add user %s: group %s does not exist", u.Username, u.GroupName))
 						assert.Equal(t, resource.StatusCantChange, status.StatusCode())
-						assert.Equal(t, fmt.Sprintf("group %s does not exist", u.GroupName), status.Messages()[0])
 						assert.True(t, status.HasChanges())
 					} else {
 						assert.EqualError(t, err, "user: not supported on this system")
@@ -184,9 +183,8 @@ func TestCheck(t *testing.T) {
 					status, err := u.Check(fakerenderer.New())
 
 					if runtime.GOOS == "linux" {
-						assert.EqualError(t, err, fmt.Sprintf("cannot add user %s", u.Username))
+						assert.EqualError(t, err, fmt.Sprintf("cannot add user %s: group gid %s does not exist", u.Username, u.GID))
 						assert.Equal(t, resource.StatusCantChange, status.StatusCode())
-						assert.Equal(t, fmt.Sprintf("group gid %s does not exist", u.GID), status.Messages()[0])
 						assert.True(t, status.HasChanges())
 					} else {
 						assert.EqualError(t, err, "user: not supported on this system")
@@ -238,9 +236,8 @@ func TestCheck(t *testing.T) {
 					status, err := u.Check(fakerenderer.New())
 
 					if runtime.GOOS == "linux" {
-						assert.EqualError(t, err, fmt.Sprintf("cannot add user %s with uid %s", u.Username, u.UID))
+						assert.EqualError(t, err, fmt.Sprintf("cannot add user %s with uid %s: group %s does not exist", u.Username, u.UID, u.GroupName))
 						assert.Equal(t, resource.StatusCantChange, status.StatusCode())
-						assert.Equal(t, fmt.Sprintf("group %s does not exist", u.GroupName), status.Messages()[0])
 						assert.True(t, status.HasChanges())
 					} else {
 						assert.EqualError(t, err, "user: not supported on this system")
@@ -272,9 +269,8 @@ func TestCheck(t *testing.T) {
 					status, err := u.Check(fakerenderer.New())
 
 					if runtime.GOOS == "linux" {
-						assert.EqualError(t, err, fmt.Sprintf("cannot add user %s with uid %s", u.Username, u.UID))
+						assert.EqualError(t, err, fmt.Sprintf("cannot add user %s with uid %s: group gid %s does not exist", u.Username, u.UID, u.GID))
 						assert.Equal(t, resource.StatusCantChange, status.StatusCode())
-						assert.Equal(t, fmt.Sprintf("group gid %s does not exist", u.GID), status.Messages()[0])
 						assert.True(t, status.HasChanges())
 					} else {
 						assert.EqualError(t, err, "user: not supported on this system")
@@ -310,9 +306,8 @@ func TestCheck(t *testing.T) {
 				status, err := u.Check(fakerenderer.New())
 
 				if runtime.GOOS == "linux" {
-					assert.EqualError(t, err, fmt.Sprintf("cannot add user %s with uid %s", u.Username, u.UID))
+					assert.EqualError(t, err, fmt.Sprintf("cannot add user %s with uid %s: user uid already exists", u.Username, u.UID))
 					assert.Equal(t, resource.StatusCantChange, status.StatusCode())
-					assert.Equal(t, fmt.Sprintf("user uid %s already exists", u.UID), status.Messages()[0])
 					assert.True(t, status.HasChanges())
 				} else {
 					assert.EqualError(t, err, "user: not supported on this system")
@@ -325,9 +320,8 @@ func TestCheck(t *testing.T) {
 				status, err := u.Check(fakerenderer.New())
 
 				if runtime.GOOS == "linux" {
-					assert.EqualError(t, err, fmt.Sprintf("cannot add user %s with uid %s", u.Username, u.UID))
+					assert.EqualError(t, err, fmt.Sprintf("cannot add user %s with uid %s: user already exists", u.Username, u.UID))
 					assert.Equal(t, resource.StatusCantChange, status.StatusCode())
-					assert.Equal(t, fmt.Sprintf("user %s already exists", u.Username), status.Messages()[0])
 					assert.True(t, status.HasChanges())
 				} else {
 					assert.EqualError(t, err, "user: not supported on this system")
@@ -344,9 +338,8 @@ func TestCheck(t *testing.T) {
 				status, err := u.Check(fakerenderer.New())
 
 				if runtime.GOOS == "linux" {
-					assert.EqualError(t, err, fmt.Sprintf("cannot add user %s with uid %s", u.Username, u.UID))
+					assert.EqualError(t, err, fmt.Sprintf("cannot add user %s with uid %s: user and uid belong to different users", u.Username, u.UID))
 					assert.Equal(t, resource.StatusCantChange, status.StatusCode())
-					assert.Equal(t, fmt.Sprintf("user %s and uid %s belong to different users", u.Username, u.UID), status.Messages()[0])
 					assert.True(t, status.HasChanges())
 				} else {
 					assert.EqualError(t, err, "user: not supported on this system")
@@ -399,7 +392,7 @@ func TestCheck(t *testing.T) {
 				if runtime.GOOS == "linux" {
 					assert.NoError(t, err)
 					assert.Equal(t, resource.StatusNoChange, status.StatusCode())
-					assert.Equal(t, fmt.Sprint("user name and uid do not exist"), status.Messages()[0])
+					assert.Equal(t, fmt.Sprintf("user %s and uid %s do not exist", u.Username, u.UID), status.Messages()[0])
 					assert.False(t, status.HasChanges())
 				} else {
 					assert.EqualError(t, err, "user: not supported on this system")
@@ -412,9 +405,8 @@ func TestCheck(t *testing.T) {
 				status, err := u.Check(fakerenderer.New())
 
 				if runtime.GOOS == "linux" {
-					assert.EqualError(t, err, fmt.Sprintf("cannot delete user %s with uid %s", u.Username, u.UID))
+					assert.EqualError(t, err, fmt.Sprintf("cannot delete user %s with uid %s: user does not exist", u.Username, u.UID))
 					assert.Equal(t, resource.StatusCantChange, status.StatusCode())
-					assert.Equal(t, fmt.Sprintf("user %s does not exist", u.Username), status.Messages()[0])
 					assert.True(t, status.HasChanges())
 				} else {
 					assert.EqualError(t, err, "user: not supported on this system")
@@ -427,9 +419,8 @@ func TestCheck(t *testing.T) {
 				status, err := u.Check(fakerenderer.New())
 
 				if runtime.GOOS == "linux" {
-					assert.EqualError(t, err, fmt.Sprintf("cannot delete user %s with uid %s", u.Username, u.UID))
+					assert.EqualError(t, err, fmt.Sprintf("cannot delete user %s with uid %s: uid does not exist", u.Username, u.UID))
 					assert.Equal(t, resource.StatusCantChange, status.StatusCode())
-					assert.Equal(t, fmt.Sprintf("user uid %s does not exist", u.UID), status.Messages()[0])
 					assert.True(t, status.HasChanges())
 				} else {
 					assert.EqualError(t, err, "user: not supported on this system")
@@ -446,9 +437,8 @@ func TestCheck(t *testing.T) {
 				status, err := u.Check(fakerenderer.New())
 
 				if runtime.GOOS == "linux" {
-					assert.EqualError(t, err, fmt.Sprintf("cannot delete user %s with uid %s", u.Username, u.UID))
+					assert.EqualError(t, err, fmt.Sprintf("cannot delete user %s with uid %s: user and uid belong to different users", u.Username, u.UID))
 					assert.Equal(t, resource.StatusCantChange, status.StatusCode())
-					assert.Equal(t, fmt.Sprintf("user %s and uid %s belong to different users", u.Username, u.UID), status.Messages()[0])
 					assert.True(t, status.HasChanges())
 				} else {
 					assert.EqualError(t, err, "user: not supported on this system")
@@ -540,8 +530,8 @@ func TestApply(t *testing.T) {
 				status, err := u.Apply()
 
 				m.AssertNotCalled(t, "AddUser", u.Username, &options)
-				assert.EqualError(t, err, fmt.Sprintf("will not attempt add: user %s", u.Username))
-				assert.Equal(t, optErr, status.Messages()[0])
+				assert.EqualError(t, err, fmt.Sprintf("will not attempt to add user %s: %s", u.Username, optErr))
+				assert.Equal(t, resource.StatusCantChange, status.StatusCode())
 			})
 
 			t.Run("no add-group gid does not exist", func(t *testing.T) {
@@ -567,8 +557,8 @@ func TestApply(t *testing.T) {
 				status, err := u.Apply()
 
 				m.AssertNotCalled(t, "AddUser", u.Username, &options)
-				assert.EqualError(t, err, fmt.Sprintf("will not attempt add: user %s", u.Username))
-				assert.Equal(t, optErr, status.Messages()[0])
+				assert.EqualError(t, err, fmt.Sprintf("will not attempt to add user %s: %s", u.Username, optErr))
+				assert.Equal(t, resource.StatusCantChange, status.StatusCode())
 			})
 
 			t.Run("no add-error adding user", func(t *testing.T) {
@@ -610,7 +600,7 @@ func TestApply(t *testing.T) {
 				status, err := u.Apply()
 
 				m.AssertNotCalled(t, "AddUser", u.Username, &options)
-				assert.EqualError(t, err, fmt.Sprintf("will not attempt add: user %s", u.Username))
+				assert.EqualError(t, err, fmt.Sprintf("will not attempt to add user %s", u.Username))
 				assert.Equal(t, resource.StatusCantChange, status.StatusCode())
 			})
 		})
@@ -665,8 +655,8 @@ func TestApply(t *testing.T) {
 				status, err := u.Apply()
 
 				m.AssertNotCalled(t, "AddUser", u.Username, &options)
-				assert.EqualError(t, err, fmt.Sprintf("will not attempt add: user %s", u.Username))
-				assert.Equal(t, optErr, status.Messages()[0])
+				assert.EqualError(t, err, fmt.Sprintf("will not attempt to add user %s: %s", u.Username, optErr))
+				assert.Equal(t, resource.StatusCantChange, status.StatusCode())
 			})
 
 			t.Run("no add-group gid does not exist", func(t *testing.T) {
@@ -694,8 +684,8 @@ func TestApply(t *testing.T) {
 				status, err := u.Apply()
 
 				m.AssertNotCalled(t, "AddUser", u.Username, &options)
-				assert.EqualError(t, err, fmt.Sprintf("will not attempt add: user %s", u.Username))
-				assert.Equal(t, optErr, status.Messages()[0])
+				assert.EqualError(t, err, fmt.Sprintf("will not attempt to add user %s: %s", u.Username, optErr))
+				assert.Equal(t, resource.StatusCantChange, status.StatusCode())
 			})
 
 			t.Run("no add-error adding user", func(t *testing.T) {
@@ -743,7 +733,7 @@ func TestApply(t *testing.T) {
 				status, err := u.Apply()
 
 				m.AssertNotCalled(t, "AddUser", u.Username, &options)
-				assert.EqualError(t, err, fmt.Sprintf("will not attempt add: user %s with uid %s", u.Username, u.UID))
+				assert.EqualError(t, err, fmt.Sprintf("will not attempt to add user %s with uid %s", u.Username, u.UID))
 				assert.Equal(t, resource.StatusCantChange, status.StatusCode())
 			})
 		})
@@ -802,7 +792,7 @@ func TestApply(t *testing.T) {
 				status, err := u.Apply()
 
 				m.AssertNotCalled(t, "DelUser", u.Username)
-				assert.EqualError(t, err, fmt.Sprintf("will not attempt delete: user %s", u.Username))
+				assert.EqualError(t, err, fmt.Sprintf("will not attempt to delete user %s", u.Username))
 				assert.Equal(t, resource.StatusCantChange, status.StatusCode())
 			})
 		})
@@ -868,7 +858,7 @@ func TestApply(t *testing.T) {
 				status, err := u.Apply()
 
 				m.AssertNotCalled(t, "DelUser", u.Username)
-				assert.EqualError(t, err, fmt.Sprintf("will not attempt delete: user %s with uid %s", u.Username, u.UID))
+				assert.EqualError(t, err, fmt.Sprintf("will not attempt to delete user %s with uid %s", u.Username, u.UID))
 				assert.Equal(t, resource.StatusCantChange, status.StatusCode())
 			})
 		})

--- a/resource/user/user_test.go
+++ b/resource/user/user_test.go
@@ -152,10 +152,10 @@ func TestCheck(t *testing.T) {
 					status, err := u.Check(fakerenderer.New())
 
 					if runtime.GOOS == "linux" {
-						assert.EqualError(t, err, fmt.Sprintf("will not add user %s", u.Username))
-						assert.Equal(t, resource.StatusFatal, status.StatusCode())
+						assert.EqualError(t, err, fmt.Sprintf("cannot add user %s", u.Username))
+						assert.Equal(t, resource.StatusCantChange, status.StatusCode())
 						assert.Equal(t, fmt.Sprintf("group %s does not exist", u.GroupName), status.Messages()[0])
-						assert.False(t, status.HasChanges())
+						assert.True(t, status.HasChanges())
 					} else {
 						assert.EqualError(t, err, "user: not supported on this system")
 					}
@@ -184,10 +184,10 @@ func TestCheck(t *testing.T) {
 					status, err := u.Check(fakerenderer.New())
 
 					if runtime.GOOS == "linux" {
-						assert.EqualError(t, err, fmt.Sprintf("will not add user %s", u.Username))
-						assert.Equal(t, resource.StatusFatal, status.StatusCode())
+						assert.EqualError(t, err, fmt.Sprintf("cannot add user %s", u.Username))
+						assert.Equal(t, resource.StatusCantChange, status.StatusCode())
 						assert.Equal(t, fmt.Sprintf("group gid %s does not exist", u.GID), status.Messages()[0])
-						assert.False(t, status.HasChanges())
+						assert.True(t, status.HasChanges())
 					} else {
 						assert.EqualError(t, err, "user: not supported on this system")
 					}
@@ -238,10 +238,10 @@ func TestCheck(t *testing.T) {
 					status, err := u.Check(fakerenderer.New())
 
 					if runtime.GOOS == "linux" {
-						assert.EqualError(t, err, fmt.Sprintf("will not add user %s with uid %s", u.Username, u.UID))
-						assert.Equal(t, resource.StatusFatal, status.StatusCode())
+						assert.EqualError(t, err, fmt.Sprintf("cannot add user %s with uid %s", u.Username, u.UID))
+						assert.Equal(t, resource.StatusCantChange, status.StatusCode())
 						assert.Equal(t, fmt.Sprintf("group %s does not exist", u.GroupName), status.Messages()[0])
-						assert.False(t, status.HasChanges())
+						assert.True(t, status.HasChanges())
 					} else {
 						assert.EqualError(t, err, "user: not supported on this system")
 					}
@@ -272,10 +272,10 @@ func TestCheck(t *testing.T) {
 					status, err := u.Check(fakerenderer.New())
 
 					if runtime.GOOS == "linux" {
-						assert.EqualError(t, err, fmt.Sprintf("will not add user %s with uid %s", u.Username, u.UID))
-						assert.Equal(t, resource.StatusFatal, status.StatusCode())
+						assert.EqualError(t, err, fmt.Sprintf("cannot add user %s with uid %s", u.Username, u.UID))
+						assert.Equal(t, resource.StatusCantChange, status.StatusCode())
 						assert.Equal(t, fmt.Sprintf("group gid %s does not exist", u.GID), status.Messages()[0])
-						assert.False(t, status.HasChanges())
+						assert.True(t, status.HasChanges())
 					} else {
 						assert.EqualError(t, err, "user: not supported on this system")
 					}
@@ -310,10 +310,10 @@ func TestCheck(t *testing.T) {
 				status, err := u.Check(fakerenderer.New())
 
 				if runtime.GOOS == "linux" {
-					assert.NoError(t, err)
-					assert.Equal(t, resource.StatusFatal, status.StatusCode())
+					assert.EqualError(t, err, fmt.Sprintf("cannot add user %s with uid %s", u.Username, u.UID))
+					assert.Equal(t, resource.StatusCantChange, status.StatusCode())
 					assert.Equal(t, fmt.Sprintf("user uid %s already exists", u.UID), status.Messages()[0])
-					assert.False(t, status.HasChanges())
+					assert.True(t, status.HasChanges())
 				} else {
 					assert.EqualError(t, err, "user: not supported on this system")
 				}
@@ -325,10 +325,10 @@ func TestCheck(t *testing.T) {
 				status, err := u.Check(fakerenderer.New())
 
 				if runtime.GOOS == "linux" {
-					assert.NoError(t, err)
-					assert.Equal(t, resource.StatusFatal, status.StatusCode())
+					assert.EqualError(t, err, fmt.Sprintf("cannot add user %s with uid %s", u.Username, u.UID))
+					assert.Equal(t, resource.StatusCantChange, status.StatusCode())
 					assert.Equal(t, fmt.Sprintf("user %s already exists", u.Username), status.Messages()[0])
-					assert.False(t, status.HasChanges())
+					assert.True(t, status.HasChanges())
 				} else {
 					assert.EqualError(t, err, "user: not supported on this system")
 				}
@@ -344,10 +344,10 @@ func TestCheck(t *testing.T) {
 				status, err := u.Check(fakerenderer.New())
 
 				if runtime.GOOS == "linux" {
-					assert.NoError(t, err)
-					assert.Equal(t, resource.StatusFatal, status.StatusCode())
+					assert.EqualError(t, err, fmt.Sprintf("cannot add user %s with uid %s", u.Username, u.UID))
+					assert.Equal(t, resource.StatusCantChange, status.StatusCode())
 					assert.Equal(t, fmt.Sprintf("user %s and uid %s belong to different users", u.Username, u.UID), status.Messages()[0])
-					assert.False(t, status.HasChanges())
+					assert.True(t, status.HasChanges())
 				} else {
 					assert.EqualError(t, err, "user: not supported on this system")
 				}
@@ -412,10 +412,10 @@ func TestCheck(t *testing.T) {
 				status, err := u.Check(fakerenderer.New())
 
 				if runtime.GOOS == "linux" {
-					assert.NoError(t, err)
-					assert.Equal(t, resource.StatusFatal, status.StatusCode())
+					assert.EqualError(t, err, fmt.Sprintf("cannot delete user %s with uid %s", u.Username, u.UID))
+					assert.Equal(t, resource.StatusCantChange, status.StatusCode())
 					assert.Equal(t, fmt.Sprintf("user %s does not exist", u.Username), status.Messages()[0])
-					assert.False(t, status.HasChanges())
+					assert.True(t, status.HasChanges())
 				} else {
 					assert.EqualError(t, err, "user: not supported on this system")
 				}
@@ -427,10 +427,10 @@ func TestCheck(t *testing.T) {
 				status, err := u.Check(fakerenderer.New())
 
 				if runtime.GOOS == "linux" {
-					assert.NoError(t, err)
-					assert.Equal(t, resource.StatusFatal, status.StatusCode())
+					assert.EqualError(t, err, fmt.Sprintf("cannot delete user %s with uid %s", u.Username, u.UID))
+					assert.Equal(t, resource.StatusCantChange, status.StatusCode())
 					assert.Equal(t, fmt.Sprintf("user uid %s does not exist", u.UID), status.Messages()[0])
-					assert.False(t, status.HasChanges())
+					assert.True(t, status.HasChanges())
 				} else {
 					assert.EqualError(t, err, "user: not supported on this system")
 				}
@@ -446,10 +446,10 @@ func TestCheck(t *testing.T) {
 				status, err := u.Check(fakerenderer.New())
 
 				if runtime.GOOS == "linux" {
-					assert.NoError(t, err)
-					assert.Equal(t, resource.StatusFatal, status.StatusCode())
+					assert.EqualError(t, err, fmt.Sprintf("cannot delete user %s with uid %s", u.Username, u.UID))
+					assert.Equal(t, resource.StatusCantChange, status.StatusCode())
 					assert.Equal(t, fmt.Sprintf("user %s and uid %s belong to different users", u.Username, u.UID), status.Messages()[0])
-					assert.False(t, status.HasChanges())
+					assert.True(t, status.HasChanges())
 				} else {
 					assert.EqualError(t, err, "user: not supported on this system")
 				}
@@ -501,12 +501,14 @@ func TestApply(t *testing.T) {
 					Username: fakeUsername,
 				}
 				m := &MockSystem{}
+				o := &MockOptions{}
 				u := user.NewUser(m)
 				u.Username = usr.Username
 				u.State = user.StatePresent
 				options := user.AddUserOptions{}
 
 				m.On("Lookup", u.Username).Return(usr, os.UnknownUserError(""))
+				o.On("SetAddUserOptions", u).Return(options, nil)
 				m.On("AddUser", u.Username, &options).Return(nil)
 				status, err := u.Apply()
 
@@ -515,22 +517,78 @@ func TestApply(t *testing.T) {
 				assert.Equal(t, fmt.Sprintf("added user %s", u.Username), status.Messages()[0])
 			})
 
+			t.Run("no add-group name does not exist", func(t *testing.T) {
+				usr := &os.User{
+					Username: fakeUsername,
+				}
+				grp := &os.Group{
+					Name: fakeGroupName,
+				}
+				m := &MockSystem{}
+				o := &MockOptions{}
+				u := user.NewUser(m)
+				u.Username = usr.Username
+				u.GroupName = grp.Name
+				u.State = user.StatePresent
+				options := user.AddUserOptions{}
+				optErr := fmt.Sprintf("group %s does not exist", u.GroupName)
+
+				m.On("Lookup", u.Username).Return(usr, os.UnknownUserError(""))
+				m.On("LookupGroup", u.GroupName).Return(grp, os.UnknownGroupError(""))
+				o.On("SetAddUserOptions", u).Return(nil, optErr)
+				m.On("AddUser", u.Username, &options).Return(nil)
+				status, err := u.Apply()
+
+				m.AssertNotCalled(t, "AddUser", u.Username, &options)
+				assert.EqualError(t, err, fmt.Sprintf("will not attempt add: user %s", u.Username))
+				assert.Equal(t, optErr, status.Messages()[0])
+			})
+
+			t.Run("no add-group gid does not exist", func(t *testing.T) {
+				usr := &os.User{
+					Username: fakeUsername,
+				}
+				grp := &os.Group{
+					Gid: fakeGID,
+				}
+				m := &MockSystem{}
+				o := &MockOptions{}
+				u := user.NewUser(m)
+				u.Username = usr.Username
+				u.GID = grp.Gid
+				u.State = user.StatePresent
+				options := user.AddUserOptions{}
+				optErr := fmt.Sprintf("group gid %s does not exist", u.GID)
+
+				m.On("Lookup", u.Username).Return(usr, os.UnknownUserError(""))
+				m.On("LookupGroupID", u.GID).Return(grp, os.UnknownGroupError(""))
+				o.On("SetAddUserOptions", u).Return(nil, optErr)
+				m.On("AddUser", u.Username, &options).Return(nil)
+				status, err := u.Apply()
+
+				m.AssertNotCalled(t, "AddUser", u.Username, &options)
+				assert.EqualError(t, err, fmt.Sprintf("will not attempt add: user %s", u.Username))
+				assert.Equal(t, optErr, status.Messages()[0])
+			})
+
 			t.Run("no add-error adding user", func(t *testing.T) {
 				usr := &os.User{
 					Username: fakeUsername,
 				}
 				m := &MockSystem{}
+				o := &MockOptions{}
 				u := user.NewUser(m)
 				u.Username = usr.Username
 				u.State = user.StatePresent
 				options := user.AddUserOptions{}
 
 				m.On("Lookup", u.Username).Return(usr, os.UnknownUserError(""))
+				o.On("SetAddUserOptions", u).Return(options, nil)
 				m.On("AddUser", u.Username, &options).Return(fmt.Errorf(""))
 				status, err := u.Apply()
 
 				m.AssertCalled(t, "AddUser", u.Username, &options)
-				assert.EqualError(t, err, fmt.Sprintf(""))
+				assert.EqualError(t, err, fmt.Sprintf("user add: "))
 				assert.Equal(t, resource.StatusFatal, status.StatusCode())
 				assert.Equal(t, fmt.Sprintf("error adding user %s", u.Username), status.Messages()[0])
 			})
@@ -540,18 +598,20 @@ func TestApply(t *testing.T) {
 					Username: fakeUsername,
 				}
 				m := &MockSystem{}
+				o := &MockOptions{}
 				u := user.NewUser(m)
 				u.Username = usr.Username
 				u.State = user.StatePresent
 				options := user.AddUserOptions{}
 
 				m.On("Lookup", u.Username).Return(usr, nil)
+				o.On("SetAddUserOptions", u).Return(options, nil)
 				m.On("AddUser", u.Username, &options).Return(nil)
 				status, err := u.Apply()
 
 				m.AssertNotCalled(t, "AddUser", u.Username, &options)
 				assert.EqualError(t, err, fmt.Sprintf("will not attempt add: user %s", u.Username))
-				assert.Equal(t, resource.StatusFatal, status.StatusCode())
+				assert.Equal(t, resource.StatusCantChange, status.StatusCode())
 			})
 		})
 
@@ -562,6 +622,7 @@ func TestApply(t *testing.T) {
 					Uid:      fakeUID,
 				}
 				m := &MockSystem{}
+				o := &MockOptions{}
 				u := user.NewUser(m)
 				u.Username = usr.Username
 				u.UID = usr.Uid
@@ -570,6 +631,7 @@ func TestApply(t *testing.T) {
 
 				m.On("Lookup", u.Username).Return(usr, os.UnknownUserError(""))
 				m.On("LookupID", u.UID).Return(usr, os.UnknownUserIdError(1))
+				o.On("SetAddUserOptions", u).Return(options, nil)
 				m.On("AddUser", u.Username, &options).Return(nil)
 				status, err := u.Apply()
 
@@ -578,12 +640,71 @@ func TestApply(t *testing.T) {
 				assert.Equal(t, fmt.Sprintf("added user %s with uid %s", u.Username, u.UID), status.Messages()[0])
 			})
 
+			t.Run("no add-group name does not exist", func(t *testing.T) {
+				usr := &os.User{
+					Username: fakeUsername,
+					Uid:      fakeUID,
+				}
+				grp := &os.Group{
+					Name: fakeGroupName,
+				}
+				m := &MockSystem{}
+				o := &MockOptions{}
+				u := user.NewUser(m)
+				u.Username = usr.Username
+				u.GroupName = grp.Name
+				u.State = user.StatePresent
+				options := user.AddUserOptions{}
+				optErr := fmt.Sprintf("group %s does not exist", u.GroupName)
+
+				m.On("Lookup", u.Username).Return(usr, os.UnknownUserError(""))
+				m.On("LookupID", u.UID).Return(usr, os.UnknownUserIdError(1))
+				m.On("LookupGroup", u.GroupName).Return(grp, os.UnknownGroupError(""))
+				o.On("SetAddUserOptions", u).Return(nil, optErr)
+				m.On("AddUser", u.Username, &options).Return(nil)
+				status, err := u.Apply()
+
+				m.AssertNotCalled(t, "AddUser", u.Username, &options)
+				assert.EqualError(t, err, fmt.Sprintf("will not attempt add: user %s", u.Username))
+				assert.Equal(t, optErr, status.Messages()[0])
+			})
+
+			t.Run("no add-group gid does not exist", func(t *testing.T) {
+				usr := &os.User{
+					Username: fakeUsername,
+					Uid:      fakeUID,
+				}
+				grp := &os.Group{
+					Gid: fakeGID,
+				}
+				m := &MockSystem{}
+				o := &MockOptions{}
+				u := user.NewUser(m)
+				u.Username = usr.Username
+				u.GID = grp.Gid
+				u.State = user.StatePresent
+				options := user.AddUserOptions{}
+				optErr := fmt.Sprintf("group gid %s does not exist", u.GID)
+
+				m.On("Lookup", u.Username).Return(usr, os.UnknownUserError(""))
+				m.On("LookupID", u.UID).Return(usr, os.UnknownUserIdError(1))
+				m.On("LookupGroupID", u.GID).Return(grp, os.UnknownGroupError(""))
+				o.On("SetAddUserOptions", u).Return(nil, optErr)
+				m.On("AddUser", u.Username, &options).Return(nil)
+				status, err := u.Apply()
+
+				m.AssertNotCalled(t, "AddUser", u.Username, &options)
+				assert.EqualError(t, err, fmt.Sprintf("will not attempt add: user %s", u.Username))
+				assert.Equal(t, optErr, status.Messages()[0])
+			})
+
 			t.Run("no add-error adding user", func(t *testing.T) {
 				usr := &os.User{
 					Username: fakeUsername,
 					Uid:      fakeUID,
 				}
 				m := &MockSystem{}
+				o := &MockOptions{}
 				u := user.NewUser(m)
 				u.Username = usr.Username
 				u.UID = usr.Uid
@@ -592,11 +713,12 @@ func TestApply(t *testing.T) {
 
 				m.On("Lookup", u.Username).Return(usr, os.UnknownUserError(""))
 				m.On("LookupID", u.UID).Return(usr, os.UnknownUserIdError(1))
+				o.On("SetAddUserOptions", u).Return(options, nil)
 				m.On("AddUser", u.Username, &options).Return(fmt.Errorf(""))
 				status, err := u.Apply()
 
 				m.AssertCalled(t, "AddUser", u.Username, &options)
-				assert.EqualError(t, err, fmt.Sprintf(""))
+				assert.EqualError(t, err, fmt.Sprintf("user add: "))
 				assert.Equal(t, resource.StatusFatal, status.StatusCode())
 				assert.Equal(t, fmt.Sprintf("error adding user %s with uid %s", u.Username, u.UID), status.Messages()[0])
 			})
@@ -607,6 +729,7 @@ func TestApply(t *testing.T) {
 					Uid:      fakeUID,
 				}
 				m := &MockSystem{}
+				o := &MockOptions{}
 				u := user.NewUser(m)
 				u.Username = usr.Username
 				u.UID = usr.Uid
@@ -615,12 +738,13 @@ func TestApply(t *testing.T) {
 
 				m.On("Lookup", u.Username).Return(usr, nil)
 				m.On("LookupID", u.UID).Return(usr, nil)
+				o.On("SetAddUserOptions", u).Return(options, nil)
 				m.On("AddUser", u.Username, &options).Return(nil)
 				status, err := u.Apply()
 
 				m.AssertNotCalled(t, "AddUser", u.Username, &options)
 				assert.EqualError(t, err, fmt.Sprintf("will not attempt add: user %s with uid %s", u.Username, u.UID))
-				assert.Equal(t, resource.StatusFatal, status.StatusCode())
+				assert.Equal(t, resource.StatusCantChange, status.StatusCode())
 			})
 		})
 	})
@@ -659,7 +783,7 @@ func TestApply(t *testing.T) {
 				status, err := u.Apply()
 
 				m.AssertCalled(t, "DelUser", u.Username)
-				assert.EqualError(t, err, fmt.Sprintf(""))
+				assert.EqualError(t, err, fmt.Sprintf("user delete: "))
 				assert.Equal(t, resource.StatusFatal, status.StatusCode())
 				assert.Equal(t, fmt.Sprintf("error deleting user %s", u.Username), status.Messages()[0])
 			})
@@ -679,7 +803,7 @@ func TestApply(t *testing.T) {
 
 				m.AssertNotCalled(t, "DelUser", u.Username)
 				assert.EqualError(t, err, fmt.Sprintf("will not attempt delete: user %s", u.Username))
-				assert.Equal(t, resource.StatusFatal, status.StatusCode())
+				assert.Equal(t, resource.StatusCantChange, status.StatusCode())
 			})
 		})
 
@@ -722,7 +846,7 @@ func TestApply(t *testing.T) {
 				status, err := u.Apply()
 
 				m.AssertCalled(t, "DelUser", u.Username)
-				assert.EqualError(t, err, fmt.Sprintf(""))
+				assert.EqualError(t, err, fmt.Sprintf("user delete: "))
 				assert.Equal(t, resource.StatusFatal, status.StatusCode())
 				assert.Equal(t, fmt.Sprintf("error deleting user %s with uid %s", u.Username, u.UID), status.Messages()[0])
 			})
@@ -745,7 +869,7 @@ func TestApply(t *testing.T) {
 
 				m.AssertNotCalled(t, "DelUser", u.Username)
 				assert.EqualError(t, err, fmt.Sprintf("will not attempt delete: user %s with uid %s", u.Username, u.UID))
-				assert.Equal(t, resource.StatusFatal, status.StatusCode())
+				assert.Equal(t, resource.StatusCantChange, status.StatusCode())
 			})
 		})
 	})
@@ -756,6 +880,7 @@ func TestApply(t *testing.T) {
 			Uid:      fakeUID,
 		}
 		m := &MockSystem{}
+		o := &MockOptions{}
 		u := user.NewUser(m)
 		u.Username = usr.Username
 		u.UID = usr.Uid
@@ -764,10 +889,12 @@ func TestApply(t *testing.T) {
 
 		m.On("Lookup", u.Username).Return(usr, nil)
 		m.On("LookupID", u.UID).Return(usr, nil)
+		o.On("SetAddUserOptions", u).Return(options, nil)
 		m.On("AddUser", u.Username, &options).Return(nil)
 		m.On("DelUser", u.Username).Return(nil)
 		status, err := u.Apply()
 
+		o.AssertNotCalled(t, "SetAddUserOptions", u)
 		m.AssertNotCalled(t, "AddUser", u.Username, &options)
 		m.AssertNotCalled(t, "DelUser", u.Username)
 		assert.EqualError(t, err, fmt.Sprintf("user: unrecognized state %s", u.State))
@@ -779,17 +906,26 @@ func TestApply(t *testing.T) {
 // are properly set
 func TestSetAddUserOptions(t *testing.T) {
 	t.Parallel()
+	gid, err := setGid()
+	if err != nil {
+		panic(err)
+	}
+	grp, err := os.LookupGroupId(gid)
+	if err != nil {
+		panic(err)
+	}
 
 	t.Run("all options", func(t *testing.T) {
 		u := user.NewUser(new(user.System))
 		u.Username = fakeUsername
 		u.UID = fakeUID
-		u.GID = fakeGID
+		u.GID = gid
 		u.Name = "test"
 		u.HomeDir = "testDir"
 
-		options := user.SetAddUserOptions(u)
+		options, err := user.SetAddUserOptions(u)
 
+		assert.NoError(t, err)
 		assert.Equal(t, u.UID, options.UID)
 		assert.Equal(t, u.GID, options.Group)
 		assert.Equal(t, u.Name, options.Comment)
@@ -797,22 +933,70 @@ func TestSetAddUserOptions(t *testing.T) {
 	})
 
 	t.Run("group options", func(t *testing.T) {
-		u := user.NewUser(new(user.System))
-		u.Username = fakeUsername
-		u.GroupName = fakeGroupName
-		u.GID = fakeGID
+		t.Run("group name and gid", func(t *testing.T) {
+			u := user.NewUser(new(user.System))
+			u.Username = fakeUsername
+			u.GroupName = grp.Name
+			u.GID = gid
 
-		options := user.SetAddUserOptions(u)
+			options, err := user.SetAddUserOptions(u)
 
-		assert.Equal(t, u.GroupName, options.Group)
+			assert.NoError(t, err)
+			assert.Equal(t, u.GroupName, options.Group)
+		})
+
+		t.Run("with group name", func(t *testing.T) {
+			u := user.NewUser(new(user.System))
+			u.Username = fakeUsername
+			u.GroupName = grp.Name
+
+			options, err := user.SetAddUserOptions(u)
+
+			assert.NoError(t, err)
+			assert.Equal(t, u.GroupName, options.Group)
+		})
+
+		t.Run("group name not found", func(t *testing.T) {
+			u := user.NewUser(new(user.System))
+			u.Username = fakeUsername
+			u.GroupName = fakeGroupName
+
+			options, err := user.SetAddUserOptions(u)
+
+			assert.EqualError(t, err, fmt.Sprintf("group %s does not exist", u.GroupName))
+			assert.Nil(t, options)
+		})
+
+		t.Run("with group gid", func(t *testing.T) {
+			u := user.NewUser(new(user.System))
+			u.Username = fakeUsername
+			u.GID = gid
+
+			options, err := user.SetAddUserOptions(u)
+
+			assert.NoError(t, err)
+			assert.Equal(t, u.GID, options.Group)
+		})
+
+		t.Run("group gid not found", func(t *testing.T) {
+			u := user.NewUser(new(user.System))
+			u.Username = fakeUsername
+			u.GID = fakeGID
+
+			options, err := user.SetAddUserOptions(u)
+
+			assert.EqualError(t, err, fmt.Sprintf("group gid %s does not exist", u.GID))
+			assert.Nil(t, options)
+		})
 	})
 
 	t.Run("no options", func(t *testing.T) {
 		u := user.NewUser(new(user.System))
 		u.Username = fakeUsername
 
-		options := user.SetAddUserOptions(u)
+		options, err := user.SetAddUserOptions(u)
 
+		assert.NoError(t, err)
 		assert.Equal(t, "", options.UID)
 		assert.Equal(t, "", options.Group)
 		assert.Equal(t, "", options.Comment)
@@ -867,6 +1051,17 @@ func setFakeGid() (string, error) {
 		}
 	}
 	return "", fmt.Errorf("setFakeGid: could not set gid")
+}
+
+// MockOptions is a mock implementation for setting user options
+type MockOptions struct {
+	mock.Mock
+}
+
+// SetAddUserOptions sets the options for adding a user
+func (m *MockOptions) SetAddUserOptions(u *user.User) (*user.AddUserOptions, error) {
+	args := m.Called(u)
+	return args.Get(0).(*user.AddUserOptions), args.Error(1)
 }
 
 // MockSystem is a mock implementation of user.System


### PR DESCRIPTION
- Updates status level and errors for user
- Adds checks in Apply() when adding a user with a group
  - Verifies that the group name or gid exists prior to adding
  - Returns useful error if the group does not exist
