### PR TITLE
0.3.0 release documentation

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -21,7 +21,7 @@ import (
 )
 
 // Version describes the version for packaging
-const Version = "0.2.0"
+const Version = "0.3.0-beta1"
 
 // versionCmd represents the version command
 var versionCmd = &cobra.Command{

--- a/docs/content/release-notes.md
+++ b/docs/content/release-notes.md
@@ -22,4 +22,4 @@ Converge is in active development. APIs are not guaranteed until a 1.0 release.
 [0.1.0](https://github.com/asteris-llc/converge/releases/tag/0.1) | 2016-06-09 | | [Milestone](https://github.com/asteris-llc/converge/milestone/1?closed=1)
 [0.1.1](https://github.com/asteris-llc/converge/releases/tag/0.1.1) | 2016-06-13 | | [Milestone](https://github.com/asteris-llc/converge/milestone/4?closed=1)
 [0.2.0]({{< ref "release-notes/0.2.0.md" >}}) | 2016-09-26 | [Project](https://github.com/asteris-llc/converge/projects/1) | [Milestone](https://github.com/asteris-llc/converge/milestone/8?closed=1)
-[0.3.0]({{< ref "release-notes/0.3.0.md" >}}) | 2016-10-20 | [Project](https://github.com/asteris-llc/converge/projects/2) | [Milestone](https://github.com/asteris-llc/converge/milestone/7?closed=1)
+[0.3.0-beta1]({{< ref "release-notes/0.3.0.md" >}}) | 2016-10-20 | [Project](https://github.com/asteris-llc/converge/projects/2) | [Milestone](https://github.com/asteris-llc/converge/milestone/7?closed=1)

--- a/docs/content/release-notes.md
+++ b/docs/content/release-notes.md
@@ -1,6 +1,6 @@
 ---
 title: "Release Notes"
-date: "2016-10-16"
+date: "2016-10-20"
 
 menu:
   main:
@@ -22,4 +22,4 @@ Converge is in active development. APIs are not guaranteed until a 1.0 release.
 [0.1.0](https://github.com/asteris-llc/converge/releases/tag/0.1) | 2016-06-09 | | [Milestone](https://github.com/asteris-llc/converge/milestone/1?closed=1)
 [0.1.1](https://github.com/asteris-llc/converge/releases/tag/0.1.1) | 2016-06-13 | | [Milestone](https://github.com/asteris-llc/converge/milestone/4?closed=1)
 [0.2.0]({{< ref "release-notes/0.2.0.md" >}}) | 2016-09-26 | [Project](https://github.com/asteris-llc/converge/projects/1) | [Milestone](https://github.com/asteris-llc/converge/milestone/8?closed=1)
-[0.3.0]({{< ref "release-notes/0.3.0.md" >}}) | _In Development_ | [Project](https://github.com/asteris-llc/converge/projects/2) | [Milestone](https://github.com/asteris-llc/converge/milestone/7?closed=1)
+[0.3.0]({{< ref "release-notes/0.3.0.md" >}}) | 2016-10-20 | [Project](https://github.com/asteris-llc/converge/projects/2) | [Milestone](https://github.com/asteris-llc/converge/milestone/7?closed=1)

--- a/docs/content/release-notes.md
+++ b/docs/content/release-notes.md
@@ -1,6 +1,6 @@
 ---
 title: "Release Notes"
-date: "2016-10-20"
+date: "2016-10-21"
 
 menu:
   main:
@@ -22,4 +22,4 @@ Converge is in active development. APIs are not guaranteed until a 1.0 release.
 [0.1.0](https://github.com/asteris-llc/converge/releases/tag/0.1) | 2016-06-09 | | [Milestone](https://github.com/asteris-llc/converge/milestone/1?closed=1)
 [0.1.1](https://github.com/asteris-llc/converge/releases/tag/0.1.1) | 2016-06-13 | | [Milestone](https://github.com/asteris-llc/converge/milestone/4?closed=1)
 [0.2.0]({{< ref "release-notes/0.2.0.md" >}}) | 2016-09-26 | [Project](https://github.com/asteris-llc/converge/projects/1) | [Milestone](https://github.com/asteris-llc/converge/milestone/8?closed=1)
-[0.3.0-beta1]({{< ref "release-notes/0.3.0.md" >}}) | 2016-10-20 | [Project](https://github.com/asteris-llc/converge/projects/2) | [Milestone](https://github.com/asteris-llc/converge/milestone/7?closed=1)
+[0.3.0-beta1]({{< ref "release-notes/0.3.0.md" >}}) | 2016-10-21 | [Project](https://github.com/asteris-llc/converge/projects/2) | [Milestone](https://github.com/asteris-llc/converge/milestone/7?closed=1)

--- a/docs/content/release-notes.md
+++ b/docs/content/release-notes.md
@@ -5,7 +5,7 @@ date: "2016-10-16"
 menu:
   main:
     identifier: release-notes
-    weight: 20
+    weight: 50
 
 ---
 
@@ -19,7 +19,7 @@ Converge is in active development. APIs are not guaranteed until a 1.0 release.
 
 | Release | Date | Project | Milestone |
 |---------|------|---------|-----------|
-[0.1.0](https://github.com/asteris-llc/converge/releases/tag/0.1) | June 9, 2016 | | [Milestone](https://github.com/asteris-llc/converge/milestone/1?closed=1)
-[0.1.1](https://github.com/asteris-llc/converge/releases/tag/0.1.1) | June 13, 2016 | | [Milestone](https://github.com/asteris-llc/converge/milestone/4?closed=1)
-[0.2.0]({{< ref "release-notes/0.2.0.md" >}}) | September 26, 2016 | [Project](https://github.com/asteris-llc/converge/projects/1) | [Milestone](https://github.com/asteris-llc/converge/milestone/8?closed=1)
+[0.1.0](https://github.com/asteris-llc/converge/releases/tag/0.1) | 2016-06-09 | | [Milestone](https://github.com/asteris-llc/converge/milestone/1?closed=1)
+[0.1.1](https://github.com/asteris-llc/converge/releases/tag/0.1.1) | 2016-06-13 | | [Milestone](https://github.com/asteris-llc/converge/milestone/4?closed=1)
+[0.2.0]({{< ref "release-notes/0.2.0.md" >}}) | 2016-09-26 | [Project](https://github.com/asteris-llc/converge/projects/1) | [Milestone](https://github.com/asteris-llc/converge/milestone/8?closed=1)
 [0.3.0]({{< ref "release-notes/0.3.0.md" >}}) | _In Development_ | [Project](https://github.com/asteris-llc/converge/projects/2) | [Milestone](https://github.com/asteris-llc/converge/milestone/7?closed=1)

--- a/docs/content/release-notes.md
+++ b/docs/content/release-notes.md
@@ -1,0 +1,25 @@
+---
+title: "Release Notes"
+date: "2016-10-16"
+
+menu:
+  main:
+    identifier: release-notes
+    weight: 20
+
+---
+
+Converge is in active development. APIs are not guaranteed until a 1.0 release.
+
+`Project` links to the project for the release.
+
+`Milestone` links to issues and pull requests for the release.
+
+## Releases
+
+| Release | Date | Project | Milestone |
+|---------|------|---------|-----------|
+[0.1.0](https://github.com/asteris-llc/converge/releases/tag/0.1) | June 9, 2016 | | [Milestone](https://github.com/asteris-llc/converge/milestone/1?closed=1)
+[0.1.1](https://github.com/asteris-llc/converge/releases/tag/0.1.1) | June 13, 2016 | | [Milestone](https://github.com/asteris-llc/converge/milestone/4?closed=1)
+[0.2.0]({{< ref "release-notes/0.2.0.md" >}}) | September 26, 2016 | [Project](https://github.com/asteris-llc/converge/projects/1) | [Milestone](https://github.com/asteris-llc/converge/milestone/8?closed=1)
+[0.3.0]({{< ref "release-notes/0.3.0.md" >}}) | _In Development_ | [Project](https://github.com/asteris-llc/converge/projects/2) | [Milestone](https://github.com/asteris-llc/converge/milestone/7?closed=1)

--- a/docs/content/release-notes/0.2.0.md
+++ b/docs/content/release-notes/0.2.0.md
@@ -1,0 +1,44 @@
+---
+title: "0.2.0"
+date: "2016-10-16"
+
+menu:
+  main:
+    parent: "release-notes"
+    identifier: 0.2.0
+    weight: 80
+---
+
+## Release Date
+
+September 26, 2016
+
+## Features
+
+- Set environments for shell commands
+- Support for Docker Containers and Images
+- Support for creating & deleting unix users and groups
+- RPC using grpc.io
+- Expose basic platform information via the platform module
+
+## Bug Fixes
+
+This releases fixes several race condition (#266) and ordering (#254) bugs that would cause Converge to error out of otherwise valid executions.
+
+If you've been trying to use boolean values in your params, you're in luck. That works now! (#251)
+
+Internally, beta 2 simplifies how `check` and `apply` interact (#240) and shrinks the Status interface (#237). Documentation for module authors will be updated by the final release of Converge 0.2.0.
+
+Lastly, logging was quite a bit too chatty about the stages Converge goes through when loading and executing a graph. This release scales logging back a bit (#248).
+
+## Examples
+
+We have new examples for Docker Swarm mode (#267) and the ELK (Elasticsearch, Logstash, and Kibana) stack (#272). They're located in the `examples/` directory of the source, and are intended to be standalone end-to-end examples.
+
+## Linting
+
+We started using Code Climate for linting in this release. We have a 4.0 (such good students.) You can [view our score using Code Climate's web interface](https://codeclimate.com/github/asteris-llc/converge) or by clicking the badge in the README.
+
+## Support
+
+We provide support via [the Converge Slack team](http://converge-slack.aster.is/) and through [GitHub issues](https://github.com/asteris-llc/converge/issues)

--- a/docs/content/release-notes/0.2.0.md
+++ b/docs/content/release-notes/0.2.0.md
@@ -1,17 +1,18 @@
 ---
 title: "0.2.0"
 date: "2016-10-16"
+slug: "0-2-0"
 
 menu:
   main:
     parent: "release-notes"
-    identifier: 0.2.0
-    weight: 80
+    identifier: 0.2.0   
+    
 ---
 
 ## Release Date
 
-September 26, 2016
+2016-09-26
 
 ## Features
 

--- a/docs/content/release-notes/0.3.0.md
+++ b/docs/content/release-notes/0.3.0.md
@@ -131,6 +131,7 @@ Text output for changes is now aligned via [#317](https://github.com/asteris-llc
 - param dependency fails in `samples/shellContext.hcl` [#313](https://github.com/asteris-llc/converge/issues/313)
 - Execution Engine Ignoring Warning Levels [#243](https://github.com/asteris-llc/converge/issues/243)
 - Make pipeline functions use mult-return instead of Either [#225](https://github.com/asteris-llc/converge/issues/225)
+- cmd/server.go: use errgroup instead of waitgroup [#363](https://github.com/asteris-llc/converge/pull/363)
 
 ## Examples/Documentation
 

--- a/docs/content/release-notes/0.3.0.md
+++ b/docs/content/release-notes/0.3.0.md
@@ -12,7 +12,7 @@ menu:
 
 ## Release Date
 
-2016-10-20
+2016-10-20 Beta
 
 ## Features
 

--- a/docs/content/release-notes/0.3.0.md
+++ b/docs/content/release-notes/0.3.0.md
@@ -12,7 +12,7 @@ menu:
 
 ## Release Date
 
-Unreleased, scheduled for the week of 10/17/2016.
+Unreleased.
 
 ## Features
 
@@ -22,7 +22,9 @@ also been simplified to make it easier for programmers to create new modules.
 
 ### Module Improvements
 
-RPM package install/uninstall support has been added via [\#373](https://github.com/asteris-llc/converge/pull/373).
+#### RPM Resource
+
+RPM package install/uninstall support has been added via [#373](https://github.com/asteris-llc/converge/pull/373).
 
 ```hcl
 rpm.package "mc" {
@@ -31,13 +33,46 @@ rpm.package "mc" {
 }
 ```
 
-Linux user groups can be modified via [\#279](https://github.com/asteris-llc/converge/issues/279)
+#### User and group
+
+Linux user groups can now be modified via [#279](https://github.com/asteris-llc/converge/issues/279)
+
+#### wait.query and wait.port
+
+Support for waiting for a task or port was [#334](https://github.com/asteris-llc/converge/pull/334). A user
+can now structure workflows where tasks can wait for a port to be open or a condition to be met.
+
+Below is an example of waiting for a port to be open using the `wait.port` resource:
+
+```hcl
+wait.port "8080" {
+  host         = "localhost"
+  port         = 8080
+  interval     = "1s"
+  max_retry    = 10
+  grace_period = "2s"
+}
+```
+
+The following shows using `wait.query` to wait using a task:
+
+```hcl
+wait.query "service-health" {
+  check        = "nc -z localhost 8080"
+  interval     = "1s"
+  max_retry    = 10
+  grace_period = "1s"
+}
+```
+
+Wait is documented at: [wait.port]({{< relref "resources/wait.port.md" >}}) and [wait.query]({{< relref "resources/wait.query.md" >}}).
+
 
 ### Engine Improvements
 
 #### Conditional Support
 
-Support for conditionals via [\#362](https://github.com/asteris-llc/converge/pull/362).
+Support for conditionals via [#362](https://github.com/asteris-llc/converge/pull/362).
 
 ```hcl
 param "lang" {
@@ -84,58 +119,24 @@ task "install-build-essential" {
 }
 ```
 
-#### Node Metadata
-
-Initial support for adding metadata to graph nodes was added via [\#369](https://github.com/asteris-llc/converge/pull/369). 
-
-#### Conditional Waits
-
-Support for waiting for a task or port was [\#334](https://github.com/asteris-llc/converge/pull/334). A user
-can now structure workflows where tasks can wait for a port to be open or a condition to be met.
-
-Below is an example of waiting for a port to be open using the `wait.port` resource:
-
-```hcl
-wait.port "8080" {
-  host         = "localhost"
-  port         = 8080
-  interval     = "1s"
-  max_retry    = 10
-  grace_period = "2s"
-}
-```
-
-The following shows using `wait.query` to wait using a task:
-
-```hcl
-wait.query "service-health" {
-  check        = "nc -z localhost 8080"
-  interval     = "1s"
-  max_retry    = 10
-  grace_period = "1s"
-}
-```
-
-Wait is documented at: [wait.port]({{< relref "resources/wait.port.md" >}}) and [wait.query]({{< relref "resources/wait.query.md" >}}).
-
 #### Output Improvements
 
-Text output for changes is now aligned via [\#317](https://github.com/asteris-llc/converge/pull/317).
+Text output for changes is now aligned via [#317](https://github.com/asteris-llc/converge/pull/317).
 
 ## Bug Fixes
 
-- docker.container regression [\#343](https://github.com/asteris-llc/converge/issues/343)
-- handle parameters with valid zero value [\#338](https://github.com/asteris-llc/converge/issues/338)
-- shell module should not set StatusLevel based on process exit code [\#323](https://github.com/asteris-llc/converge/issues/323)
-- param dependency fails in `samples/shellContext.hcl` [\#313](https://github.com/asteris-llc/converge/issues/313)
-- Execution Engine Ignoring Warning Levels [\#243](https://github.com/asteris-llc/converge/issues/243)
-- Make pipeline functions use mult-return instead of Either [\#225](https://github.com/asteris-llc/converge/issues/225)
+- docker.container regression [#343](https://github.com/asteris-llc/converge/issues/343)
+- handle parameters with valid zero value [#338](https://github.com/asteris-llc/converge/issues/338)
+- shell module should not set StatusLevel based on process exit code [#323](https://github.com/asteris-llc/converge/issues/323)
+- param dependency fails in `samples/shellContext.hcl` [#313](https://github.com/asteris-llc/converge/issues/313)
+- Execution Engine Ignoring Warning Levels [#243](https://github.com/asteris-llc/converge/issues/243)
+- Make pipeline functions use mult-return instead of Either [#225](https://github.com/asteris-llc/converge/issues/225)
 
 ## Examples/Documentation
 
-A Docker image was created in [\#372](https://github.com/asteris-llc/converge/pull/372) to speed up Wercker builds and automated tests.
+A Docker image was created in [#372](https://github.com/asteris-llc/converge/pull/372) to speed up Wercker builds and automated tests.
 
-Documentation was updated in [\#371](https://github.com/asteris-llc/converge/pull/371) so that links like
+Documentation was updated in [#371](https://github.com/asteris-llc/converge/pull/371) so that links like
 [converge.aster.is/0.2.0](https://converge.aster.is/0.2.0) will resolve documentation for that version.
 
 ## Support

--- a/docs/content/release-notes/0.3.0.md
+++ b/docs/content/release-notes/0.3.0.md
@@ -12,7 +12,7 @@ menu:
 
 ## Release Date
 
-2016-10-20 Beta
+2016-10-21 0.3.0-beta1
 
 ## Features
 

--- a/docs/content/release-notes/0.3.0.md
+++ b/docs/content/release-notes/0.3.0.md
@@ -1,12 +1,13 @@
 ---
 title: "0.3.0"
 date: "2016-10-20"
+slug: "0-3-0"
 
 menu:
   main:
     parent: "release-notes"
     identifier: 0.3.0
-    weight: 80
+
 ---
 
 ## Release Date
@@ -15,10 +16,28 @@ Unreleased, scheduled for the week of 10/17/2016.
 
 ## Features
 
-RPM package install/uninstall support was added in [\#373](https://github.com/asteris-llc/converge/pull/373).
+This release includes a number of significant improvements to the core engine including conditionals,
+wait queries, named locks, and the ability to use lists and maps in parameters. The internal API has
+also been simplified to make it easier for programmers to create new modules.
 
-Support for conditionals in [\#362](https://github.com/asteris-llc/converge/pull/362). This means you can now
-define workflows like the following:
+### Module Improvements
+
+RPM package install/uninstall support has been added via [\#373](https://github.com/asteris-llc/converge/pull/373).
+
+```hcl
+rpm.package "mc" {
+    name  = "mc"
+    state = "present"
+}
+```
+
+Linux user groups can be modified via [\#279](https://github.com/asteris-llc/converge/issues/279)
+
+### Engine Improvements
+
+#### Conditional Support
+
+Support for conditionals via [\#362](https://github.com/asteris-llc/converge/pull/362).
 
 ```hcl
 param "lang" {
@@ -42,16 +61,82 @@ switch "test-switch" {
 
 ```
 
-Documentation was updated in [\#371](https://github.com/asteris-llc/converge/pull/371) so that links like
-[converge.aster.is/0.2.0](https://converge.aster.is/0.2.0) will resolve documentation for that version.
+#### Named Locks
+
+Basic locks have been added to the engine. This allows worksflows where multiple tasks run
+one at a time instead of in parallel. Locks are added as a node in the graph and released
+after all tasks sharing the lock are complete.
+
+For example, `apt` package installs cannot run in parallel. In the following example
+each task with the `apt` lock is run sequentually.
+
+```hcl
+task "install-jq" {
+  check = "dpkg -s jq >/dev/null 2>&1"
+  apply = "apt-get update 2>&1 > /dev/null && apt-get -y install jq"
+  lock  = "apt"
+}
+
+task "install-build-essential" {
+  check = "dpkg -s build-essential >/dev/null 2>&1"
+  apply = "apt-get update 2>&1 > /dev/null && apt-get -y install build-essential"
+  lock  = "apt"
+}
+```
+
+#### Node Metadata
+
+Initial support for adding metadata to graph nodes was added via [\#369](https://github.com/asteris-llc/converge/pull/369). 
+
+#### Conditional Waits
+
+Support for waiting for a task or port was [\#334](https://github.com/asteris-llc/converge/pull/334). A user
+can now structure workflows where tasks can wait for a port to be open or a condition to be met.
+
+Below is an example of waiting for a port to be open using the `wait.port` resource:
+
+```hcl
+wait.port "8080" {
+  host         = "localhost"
+  port         = 8080
+  interval     = "1s"
+  max_retry    = 10
+  grace_period = "2s"
+}
+```
+
+The following shows using `wait.query` to wait using a task:
+
+```hcl
+wait.query "service-health" {
+  check        = "nc -z localhost 8080"
+  interval     = "1s"
+  max_retry    = 10
+  grace_period = "1s"
+}
+```
+
+Wait is documented at: [wait.port]({{< relref "resources/wait.port.md" >}}) and [wait.query]({{< relref "resources/wait.query.md" >}}).
+
+#### Output Improvements
+
+Text output for changes is now aligned via [\#317](https://github.com/asteris-llc/converge/pull/317).
 
 ## Bug Fixes
 
-This releases fixes several race condition (#266) and ordering (#254) bugs that would cause Converge to error out of otherwise valid executions.
+- docker.container regression [\#343](https://github.com/asteris-llc/converge/issues/343)
+- handle parameters with valid zero value [\#338](https://github.com/asteris-llc/converge/issues/338)
+- shell module should not set StatusLevel based on process exit code [\#323](https://github.com/asteris-llc/converge/issues/323)
+- param dependency fails in `samples/shellContext.hcl` [\#313](https://github.com/asteris-llc/converge/issues/313)
+- Execution Engine Ignoring Warning Levels [\#243](https://github.com/asteris-llc/converge/issues/243)
+- Make pipeline functions use mult-return instead of Either [\#225](https://github.com/asteris-llc/converge/issues/225)
 
-## Examples
+## Examples/Documentation
 
 A Docker image was created in [\#372](https://github.com/asteris-llc/converge/pull/372) to speed up Wercker builds and automated tests.
+
+Documentation was updated in [\#371](https://github.com/asteris-llc/converge/pull/371) so that links like
+[converge.aster.is/0.2.0](https://converge.aster.is/0.2.0) will resolve documentation for that version.
 
 ## Support
 

--- a/docs/content/release-notes/0.3.0.md
+++ b/docs/content/release-notes/0.3.0.md
@@ -1,0 +1,58 @@
+---
+title: "0.3.0"
+date: "2016-10-20"
+
+menu:
+  main:
+    parent: "release-notes"
+    identifier: 0.3.0
+    weight: 80
+---
+
+## Release Date
+
+Unreleased, scheduled for the week of 10/17/2016.
+
+## Features
+
+RPM package install/uninstall support was added in [\#373](https://github.com/asteris-llc/converge/pull/373).
+
+Support for conditionals in [\#362](https://github.com/asteris-llc/converge/pull/362). This means you can now
+define workflows like the following:
+
+```hcl
+param "lang" {
+  default = ""
+}
+
+switch "test-switch" {
+  case "eq `spanish` `{{param `lang`}}`" "spanish" {
+    file.content "foo-file" {
+      destination = "greeting.txt"
+      content     = "hola\n"
+    }
+  }
+
+  case "eq `french` `{{param `lang`}}`" "french" {
+    file.content "foo-file" {
+      destination = "greeting.txt"
+      content     = "salut\n"
+    }
+  }
+
+```
+
+Documentation was updated in [\#371](https://github.com/asteris-llc/converge/pull/371) so that links like
+[converge.aster.is/0.2.0](https://converge.aster.is/0.2.0) will resolve documentation for that version.
+
+## Bug Fixes
+
+This releases fixes several race condition (#266) and ordering (#254) bugs that would cause Converge to error out of otherwise valid executions.
+
+## Examples
+
+A Docker image was created in [\#372](https://github.com/asteris-llc/converge/pull/372) to speed up Wercker builds and automated tests.
+
+## Support
+
+We provide support via [the Converge Slack team](http://converge-slack.aster.is/) and through [GitHub issues](https://github.com/asteris-llc/converge/issues)

--- a/docs/content/release-notes/0.3.0.md
+++ b/docs/content/release-notes/0.3.0.md
@@ -98,7 +98,7 @@ switch "test-switch" {
 
 #### Named Locks
 
-Basic locks have been added to the engine. This allows worksflows where multiple tasks run
+Basic locks have been added to the engine. This allows workflows where multiple tasks run
 one at a time instead of in parallel. Locks are added as a node in the graph and released
 after all tasks sharing the lock are complete.
 

--- a/docs/content/release-notes/0.3.0.md
+++ b/docs/content/release-notes/0.3.0.md
@@ -74,6 +74,9 @@ Wait is documented at: [wait.port]({{< relref "resources/wait.port.md" >}}) and 
 
 Support for conditionals via [#362](https://github.com/asteris-llc/converge/pull/362).
 
+In the following example, the contents of file `greetings.txt` depend on the value of
+the `lang` parameter:
+
 ```hcl
 param "lang" {
   default = ""
@@ -103,7 +106,7 @@ one at a time instead of in parallel. Locks are added as a node in the graph and
 after all tasks sharing the lock are complete.
 
 For example, `apt` package installs cannot run in parallel. In the following example
-each task with the `apt` lock is run sequentually.
+each task with the `apt` lock is run sequentially.
 
 ```hcl
 task "install-jq" {
@@ -118,6 +121,12 @@ task "install-build-essential" {
   lock  = "apt"
 }
 ```
+
+#### Enhanced Parameter Values
+
+`bool`, `list`, and `map` types have been added to parameters via [#340](https://github.com/asteris-llc/converge/pull/340).
+
+See [values]({{< ref "params-and-templates.md#Values" >}})
 
 #### Output Improvements
 

--- a/docs/content/release-notes/0.3.0.md
+++ b/docs/content/release-notes/0.3.0.md
@@ -12,12 +12,12 @@ menu:
 
 ## Release Date
 
-Unreleased.
+2016-10-20
 
 ## Features
 
 This release includes a number of significant improvements to the core engine including conditionals,
-wait queries, named locks, and the ability to use lists and maps in parameters. The internal API has
+wait queries, sequential task groups, and the ability to use lists and maps in parameters. The internal API has
 also been simplified to make it easier for programmers to create new modules.
 
 ### Module Improvements
@@ -39,8 +39,8 @@ Linux user groups can now be modified via [#279](https://github.com/asteris-llc/
 
 #### wait.query and wait.port
 
-Support for waiting for a task or port was [#334](https://github.com/asteris-llc/converge/pull/334). A user
-can now structure workflows where tasks can wait for a port to be open or a condition to be met.
+Converge now supports waiting for a task to complete or port [#334](https://github.com/asteris-llc/converge/pull/334).
+Users can create a dependency for a port to be open or a condition to be met.
 
 Below is an example of waiting for a port to be open using the `wait.port` resource:
 
@@ -99,11 +99,11 @@ switch "test-switch" {
 
 ```
 
-#### Named Locks
+#### Task Groups
 
-Basic locks have been added to the engine. This allows workflows where multiple tasks run
+Tasks can be assigned to a group to force multiple tasks to run
 one at a time instead of in parallel. Locks are added as a node in the graph and released
-after all tasks sharing the lock are complete.
+after all tasks sharing the lock are complete. [#392](https://github.com/asteris-llc/converge/pull/392)
 
 For example, `apt` package installs cannot run in parallel. In the following example
 each task with the `apt` lock is run sequentially.
@@ -112,13 +112,13 @@ each task with the `apt` lock is run sequentially.
 task "install-jq" {
   check = "dpkg -s jq >/dev/null 2>&1"
   apply = "apt-get update 2>&1 > /dev/null && apt-get -y install jq"
-  lock  = "apt"
+  group  = "apt"
 }
 
 task "install-build-essential" {
   check = "dpkg -s build-essential >/dev/null 2>&1"
   apply = "apt-get update 2>&1 > /dev/null && apt-get -y install build-essential"
-  lock  = "apt"
+  group  = "apt"
 }
 ```
 
@@ -130,7 +130,10 @@ See [values]({{< ref "params-and-templates.md#Values" >}})
 
 #### Output Improvements
 
+Rendered graphs have been cleaned and arrows now indicate the order of tasks [#387](https://github.com/asteris-llc/converge/pull/387).
+
 Text output for changes is now aligned via [#317](https://github.com/asteris-llc/converge/pull/317).
+
 
 ## Bug Fixes
 


### PR DESCRIPTION
Before 0.3.0 release tag:
- update release notes and changelog
- update `cmd/version.go`