### PR TITLE
Fix lookup calls to use os/user in SetAddUserOptions

### DIFF
--- a/resource/user/user.go
+++ b/resource/user/user.go
@@ -311,13 +311,13 @@ func SetAddUserOptions(u *User) (*AddUserOptions, error) {
 
 	switch {
 	case u.GroupName != "":
-		_, err := u.system.LookupGroup(u.GroupName)
+		_, err := user.LookupGroup(u.GroupName)
 		if err != nil {
 			return nil, fmt.Errorf("group %s does not exist", u.GroupName)
 		}
 		options.Group = u.GroupName
 	case u.GID != "":
-		_, err := u.system.LookupGroupID(u.GID)
+		_, err := user.LookupGroupId(u.GID)
 		if err != nil {
 			return nil, fmt.Errorf("group gid %s does not exist", u.GID)
 		}


### PR DESCRIPTION
Was using the system specific implementation (SystemUtils) for Group and GroupId lookups; this caused issues in testing with systems that have not been implemented for user. 

Changed the calls in SetAddUserOptions() to use os/user lookups for Group and GroupId.