### PR TITLE
Fix/385 dependencies in conditionals

### DIFF
--- a/load/dependencyresolver_test.go
+++ b/load/dependencyresolver_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestDependencyResolverResolvesDependencies tests dependency resolution
 func TestDependencyResolverResolvesDependencies(t *testing.T) {
 	defer logging.HideLogs(t)()
 
@@ -40,6 +41,8 @@ func TestDependencyResolverResolvesDependencies(t *testing.T) {
 	)
 }
 
+// TestDependencyResolverResolvesExplicitDepsInBranch tests explicit
+// dependencies inside of case branch nodes
 func TestDependencyResolverResolvesExplicitDepsInBranch(t *testing.T) {
 	defer logging.HideLogs(t)()
 

--- a/load/dependencyresolver_test.go
+++ b/load/dependencyresolver_test.go
@@ -40,6 +40,21 @@ func TestDependencyResolverResolvesDependencies(t *testing.T) {
 	)
 }
 
+func TestDependencyResolverResolvesExplicitDepsInBranch(t *testing.T) {
+	defer logging.HideLogs(t)()
+
+	nodes, err := load.Nodes(context.Background(), "../samples/conditionalDeps.hcl", false)
+	require.NoError(t, err)
+
+	resolved, err := load.ResolveDependencies(context.Background(), nodes)
+	assert.NoError(t, err)
+	assert.Contains(
+		t,
+		graph.Targets(resolved.DownEdges("root/macro.switch.sample/macro.case.true/file.content.foo-output")),
+		"root/task.query.foo",
+	)
+}
+
 func TestDependencyResolverBadDependency(t *testing.T) {
 	defer logging.HideLogs(t)()
 
@@ -48,7 +63,7 @@ func TestDependencyResolverBadDependency(t *testing.T) {
 
 	_, err = load.ResolveDependencies(context.Background(), nodes)
 	if assert.Error(t, err) {
-		assert.EqualError(t, err, "nonexistent vertices in edges: root/task.nonexistent")
+		assert.EqualError(t, err, "1 error(s) occurred:\n\n* root/task.bad_requirement: nonexistent vertices in edges: task.nonexistent")
 	}
 }
 

--- a/samples/conditionalDeps.hcl
+++ b/samples/conditionalDeps.hcl
@@ -1,0 +1,12 @@
+task.query "foo" {
+  query = "echo foo"
+}
+
+switch "sample" {
+  case "true" "true" {
+    file.content "foo-output" {
+      destination = "foo-file.txt"
+      content     = "{{lookup `task.query.foo.status.stdout`}}"
+    }
+  }
+}

--- a/samples/conditionalDeps.hcl
+++ b/samples/conditionalDeps.hcl
@@ -2,11 +2,25 @@ task.query "foo" {
   query = "echo foo"
 }
 
+task.query "bar" {
+  query = "echo bar"
+}
+
 switch "sample" {
   case "true" "true" {
+    task.query "baz" {
+      query = "echo baz"
+    }
+
+    file.content "baz" {
+      destination = "baz-file.txt"
+      content     = "{{lookup `task.query.baz.status.stdout`}}"
+    }
+
     file.content "foo-output" {
       destination = "foo-file.txt"
       content     = "{{lookup `task.query.foo.status.stdout`}}"
+      depends     = ["task.query.bar", "file.content.baz"]
     }
   }
 }

--- a/transform/control.go
+++ b/transform/control.go
@@ -74,10 +74,6 @@ func getSwitchNode(id string, g *graph.Graph) (*control.SwitchTask, bool) {
 		return nil, false
 	}
 	elem := elemMeta.Value()
-	elem, canResolve := resource.ResolveTask(elem)
-	if !canResolve {
-		return nil, false
-	}
 	if asSwitch, ok := elem.(*control.SwitchTask); ok {
 		return asSwitch, true
 	}
@@ -90,10 +86,6 @@ func getCaseNode(id string, g *graph.Graph) (*control.CaseTask, bool) {
 		return nil, false
 	}
 	elem := elemMeta.Value()
-	elem, canResolve := resource.ResolveTask(elem)
-	if !canResolve {
-		return nil, false
-	}
 	if asCase, ok := elem.(*control.CaseTask); ok {
 		return asCase, true
 	}


### PR DESCRIPTION
fix `depends =` clause in branch nodes, and fix regression related to premature unwrapping of branch macro nodes.