### PR TITLE
Allow lists in parameters when called in a module

### DIFF
--- a/helpers/fakerenderer/fakerenderer.go
+++ b/helpers/fakerenderer/fakerenderer.go
@@ -14,10 +14,12 @@
 
 package fakerenderer
 
+import "github.com/asteris-llc/converge/resource"
+
 // FakeRenderer is a pass-through renderer for testing resources
 type FakeRenderer struct {
 	ID           string
-	DotValue     string
+	DotValue     resource.Value
 	ValuePresent bool
 }
 
@@ -27,7 +29,7 @@ func (fr *FakeRenderer) GetID() string {
 }
 
 // Value returns a blank string
-func (fr *FakeRenderer) Value() (string, bool) {
+func (fr *FakeRenderer) Value() (resource.Value, bool) {
 	return fr.DotValue, fr.ValuePresent
 }
 

--- a/helpers/fakerenderer/fakerenderer.go
+++ b/helpers/fakerenderer/fakerenderer.go
@@ -28,7 +28,7 @@ func (fr *FakeRenderer) GetID() string {
 	return fr.ID
 }
 
-// Value returns a blank string
+// Value returns the dotvalue
 func (fr *FakeRenderer) Value() (resource.Value, bool) {
 	return fr.DotValue, fr.ValuePresent
 }

--- a/parse/preprocessor/switch/control_test.go
+++ b/parse/preprocessor/switch/control_test.go
@@ -37,7 +37,7 @@ func (m *MockRenderer) GetID() string {
 }
 
 // Value is a mock value
-func (m *MockRenderer) Value() (string, bool) {
+func (m *MockRenderer) Value() (resource.Value, bool) {
 	args := m.Called()
 	return args.String(0), args.Bool(1)
 }

--- a/render/render.go
+++ b/render/render.go
@@ -31,7 +31,7 @@ import (
 )
 
 // Values for rendering
-type Values map[string]interface{}
+type Values map[string]resource.Value
 
 // Render a graph with the provided values
 func Render(ctx context.Context, g *graph.Graph, top Values) (*graph.Graph, error) {

--- a/render/renderer.go
+++ b/render/renderer.go
@@ -38,7 +38,7 @@ func (ErrUnresolvable) Error() string { return "node is unresolvable" }
 type Renderer struct {
 	Graph           func() *graph.Graph
 	ID              string
-	DotValue        string
+	DotValue        resource.Value
 	DotValuePresent bool
 	resolverErr     bool
 	Language        *extensions.LanguageExtension
@@ -50,7 +50,7 @@ func (r *Renderer) GetID() string {
 }
 
 // Value of this renderer
-func (r *Renderer) Value() (value string, present bool) {
+func (r *Renderer) Value() (value resource.Value, present bool) {
 	return r.DotValue, r.DotValuePresent
 }
 

--- a/resource/module/module.go
+++ b/resource/module/module.go
@@ -25,7 +25,7 @@ import (
 type Module struct {
 	resource.Status
 
-	Params map[string]string
+	Params map[string]resource.Value
 }
 
 // Check just returns the current value of the moduleeter. It should never have to change.

--- a/resource/module/preparer.go
+++ b/resource/module/preparer.go
@@ -27,11 +27,11 @@ import (
 type Preparer struct {
 	// Params is a map of strings to anything you'd like. It will be passed to
 	// the called module as the default values for the `param`s there.
-	Params map[string]interface{} `hcl:"params"`
+	Params map[string]resource.Value `hcl:"params"`
 }
 
 // NewPreparer returns a new preparer for modules
-func NewPreparer(params map[string]interface{}) *Preparer {
+func NewPreparer(params map[string]resource.Value) *Preparer {
 	return &Preparer{Params: params}
 }
 

--- a/resource/module/preparer.go
+++ b/resource/module/preparer.go
@@ -15,8 +15,6 @@
 package module
 
 import (
-	"fmt"
-
 	"github.com/asteris-llc/converge/load/registry"
 	"github.com/asteris-llc/converge/resource"
 )
@@ -37,19 +35,7 @@ func NewPreparer(params map[string]resource.Value) *Preparer {
 
 // Prepare a new task
 func (p *Preparer) Prepare(render resource.Renderer) (resource.Task, error) {
-	module := &Module{Params: map[string]string{}}
-
-	for key, value := range p.Params {
-		switch v := value.(type) {
-		case string:
-			module.Params[key] = v
-
-		default:
-			module.Params[key] = fmt.Sprintf("%v", value)
-		}
-	}
-
-	return module, nil
+	return &Module{Params: p.Params}, nil
 }
 
 func init() {

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -33,10 +33,13 @@ type Resource interface {
 	Prepare(Renderer) (Task, error)
 }
 
+// Value is anything that can be in a renderer's Value
+type Value interface{}
+
 // Renderer is passed to resources
 type Renderer interface {
 	GetID() string
-	Value() (value string, present bool)
+	Value() (value Value, present bool)
 	Render(name, content string) (string, error)
 }
 

--- a/samples/sourceFileParamJoin.hcl
+++ b/samples/sourceFileParamJoin.hcl
@@ -1,0 +1,5 @@
+module "paramJoin.hcl" "paramJoin" {
+  params {
+    items = ["a", "b", "c"]
+  }
+}


### PR DESCRIPTION
This allows literal lists in parameters when calling a module.

Fixes #397 