### PR TITLE
Nightly/test builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ samples/**/*.png
 
 # release
 build
+cmd/version_number.go
 
 # docs
 docs/extract

--- a/Makefile
+++ b/Makefile
@@ -94,8 +94,8 @@ vendor-clean: ${NOVENDOR}
 xcompile: rpc/pb/root.pb.go rpc/pb/root.pb.gw.go test
 	@echo "package cmd" > cmd/version_number.go
 	@echo >> cmd/version_number.go
-	@echo "const Version = \"$(shell git describe --dirty)\"" >> cmd/version_number.go
-	@echo "set version to $(shell git describe --dirty)"
+	@echo "const Version = \"$(shell git describe)\"" >> cmd/version_number.go
+	@echo "set version to $(shell git describe)"
 
 	@rm -rf build/
 	@mkdir -p build/

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 NAME = $(shell awk -F\" '/^const Name/ { print $$2 }' cmd/root.go)
-VERSION = $(shell awk -F\" '/^const Version/ { print $$2 }' cmd/version.go)
 RPCLINT=$(shell find ./rpc -type f \( -not -iname 'root.*.go' -iname '*.go' \) )
 TOLINT = $(shell find . -type f \( -not -ipath './vendor*'  -not -ipath './docs*' -not -ipath './rpc*' -not -iname 'main.go' -iname '*.go' \) -exec dirname {} \; | sort -u)
 TESTDIRS = $(shell find . -name '*_test.go' -exec dirname \{\} \; | grep -v vendor | uniq)
@@ -97,7 +96,7 @@ xcompile: rpc/pb/root.pb.go rpc/pb/root.pb.gw.go test
 		-os="linux" \
 		-os="freebsd" \
 		-os="solaris" \
-		-output="build/$(NAME)_$(VERSION)_{{.OS}}_{{.Arch}}/$(NAME)"
+		-output="build/$(NAME)_$(shell git describe --dirty)_{{.OS}}_{{.Arch}}/$(NAME)"
 
 package: xcompile
 	@mkdir -p build/tgz

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get install -y unzip && \
     apt-get purge -y unzip
 
 # install gox
-RUN go get github.com/mitchellh/gox
+RUN go get -v github.com/mitchellh/gox
 
 WORKDIR /go
 CMD /bin/bash

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -15,5 +15,8 @@ RUN apt-get install -y unzip && \
     go get -v github.com/golang/protobuf/protoc-gen-go github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger && \
     apt-get purge -y unzip
 
+# install gox
+RUN go get github.com/mitchellh/gox
+
 WORKDIR /go
 CMD /bin/bash

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -20,9 +20,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Version describes the version for packaging
-const Version = "0.3.0-beta1"
-
 // versionCmd represents the version command
 var versionCmd = &cobra.Command{
 	Use:   "version",

--- a/wercker.yml
+++ b/wercker.yml
@@ -24,7 +24,7 @@ publish:
     - script:
         name: prepare for sync
         code: |
-          DEST="$(git describe --dirty)"
+          DEST="$(git describe)"
           mv build build.tmp
           mkdir -p "build/$DEST"
           mv build.tmp/* "build/$DEST"

--- a/wercker.yml
+++ b/wercker.yml
@@ -29,8 +29,8 @@ publish:
           mkdir -p "build/$DEST"
           mv build.tmp/* "build/$DEST"
 
-    - wercker/s3sync@2.1.0:
-        source_dir: go/src/github.com/asteris-llc/converge/build
+    - nextgxdx/s3sync@2.0.5:
+        source_dir: /go/src/github.com/asteris-llc/converge/build
         bucket-url: $AWS_BUCKET_URL
         key-id: $AWS_ACCESS_KEY_ID
         key-secret: $AWS_SECRET_ACCESS_KEY

--- a/wercker.yml
+++ b/wercker.yml
@@ -30,7 +30,7 @@ publish:
           mv build.tmp/* "build/$DEST"
 
     - wercker/s3sync@2.1.0:
-        source_dir: build
+        source_dir: go/src/github.com/asteris-llc/converge/build
         bucket-url: $AWS_BUCKET_URL
         key-id: $AWS_ACCESS_KEY_ID
         key-secret: $AWS_SECRET_ACCESS_KEY

--- a/wercker.yml
+++ b/wercker.yml
@@ -25,11 +25,12 @@ publish:
         name: prepare for sync
         code: |
           DEST="$(git describe --dirty)"
-          mkdir -p "nightly/$DEST"
-          mv build/tgz/* "nightly/$DEST"
+          mv build build.tmp
+          mkdir -p "build/$DEST"
+          mv build.tmp/* "build/$DEST"
 
     - wercker/s3sync@2.1.0:
-        source_dir: nightly
+        source_dir: build
         bucket-url: $AWS_BUCKET_URL
         key-id: $AWS_ACCESS_KEY_ID
         key-secret: $AWS_SECRET_ACCESS_KEY

--- a/wercker.yml
+++ b/wercker.yml
@@ -10,3 +10,26 @@ build:
         name: go test
         code: |
           make test
+
+publish:
+  box: asteris/converge-ci
+  steps:
+    - setup-go-workspace
+
+    - script:
+        name: make packages
+        code: |
+          make package
+
+    - script:
+        name: prepare for sync
+        code: |
+          DEST="$(git describe --dirty)"
+          mkdir -p "nightly/$DEST"
+          mv build/tgz/* "nightly/$DEST"
+
+    - wercker/s3sync@2.1.0:
+        source_dir: nightly
+        bucket-url: $AWS_BUCKET_URL
+        key-id: $AWS_ACCESS_KEY_ID
+        key-secret: $AWS_SECRET_ACCESS_KEY


### PR DESCRIPTION
This configuration will:

1. tag all releases made with `make converge` with the correct version metadata
2. do the same, but for CI
3. upload those releases to S3 when built on master (I've already added the pipeline steps in Wercker)