### PR TITLE
 use ldflags to set version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,6 @@ samples/**/*.png
 
 # release
 build
-cmd/version_number.go
 
 # docs
 docs/extract

--- a/Makefile
+++ b/Makefile
@@ -5,14 +5,10 @@ TESTDIRS = $(shell find . -name '*_test.go' -exec dirname \{\} \; | grep -v vend
 NONVENDOR = ${shell find . -name '*.go' | grep -v vendor}
 BENCHDIRS= $(shell find . -name '*_test.go' | grep -v vendor | xargs grep '*testing.B' | cut -d: -f1 | xargs -n1 dirname | uniq)
 BENCH = .
+REPO = github.com/asteris-llc/converge
 
-converge: $(shell find . -name '*.go' -not -name 'version_number.go') rpc/pb/root.pb.go rpc/pb/root.pb.gw.go
-	@echo "package cmd" > cmd/version_number.go
-	@echo >> cmd/version_number.go
-	@echo "const Version = \"$(shell git describe --dirty)\"" >> cmd/version_number.go
-	@echo "set version to $(shell git describe --dirty)"
-
-	go build -ldflags="-s -w" .
+converge: $(shell find . -name '*.go') rpc/pb/root.pb.go rpc/pb/root.pb.gw.go
+	go build -ldflags="-X ${REPO}/cmd.Version=$(shell git describe --dirty) -s -w" .
 
 test: converge gotest samples/*.hcl samples/errors/*.hcl blackbox/*.sh
 	@echo
@@ -92,15 +88,12 @@ vendor-clean: ${NOVENDOR}
 	find vendor -not -name '*.go' -not -name '*.s' -not -name '*.pl' -not -name '*.c' -not -name LICENSE -not -name '*.proto' -type f -delete
 
 xcompile: rpc/pb/root.pb.go rpc/pb/root.pb.gw.go test
-	@echo "package cmd" > cmd/version_number.go
-	@echo >> cmd/version_number.go
-	@echo "const Version = \"$(shell git describe)\"" >> cmd/version_number.go
 	@echo "set version to $(shell git describe)"
 
 	@rm -rf build/
 	@mkdir -p build/
 	gox \
-    -ldflags="-s -w" \
+    -ldflags="-X ${REPO}/cmd.Version=$(shell git describe) -s -w" \
 		-osarch="darwin/386" \
 		-osarch="darwin/amd64" \
 		-os="linux" \
@@ -133,4 +126,4 @@ rpc/pb/root.swagger.json: rpc/pb/root.proto
 	 --swagger_out=logtostderr=true:rpc/pb \
 	 rpc/pb/root.proto
 
-.PHONY: cmd/version_number.go test gotest vendor-update vendor-clean xcompile package samples/errors/*.hcl blackbox/*.sh lint bench license-check
+.PHONY: test gotest vendor-update vendor-clean xcompile package samples/errors/*.hcl blackbox/*.sh lint bench license-check

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -20,6 +20,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// Version is pulled from git during a build
+var Version = "unset"
+
 // versionCmd represents the version command
 var versionCmd = &cobra.Command{
 	Use:   "version",


### PR DESCRIPTION
The current version that creates a .go file interferes with `go get` on our repository. 

This version uses ldflags at build time, and will display `unset` if converge is built outside of
the make process. 