### PR TITLE
Fix/415 parent edges

### DIFF
--- a/graph/graph.go
+++ b/graph/graph.go
@@ -193,8 +193,9 @@ func (g *Graph) Disconnect(from, to string) {
 
 // SafeDisconnect disconnects two vertices by IDs but only if valid
 func (g *Graph) SafeDisconnect(from, to string) error {
-	if _, ok := g.GetParentID(to); ok {
-		return errors.New("parent edge removal considered unsafe")
+	if parentID, ok := g.GetParentID(to); ok && parentID == from {
+		// return errors.New("parent edge removal considered unsafe")
+		return nil
 	}
 
 	g.innerLock.Lock()

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -99,8 +99,8 @@ func (g *Graph) GetParent(id string) (*node.Node, bool) {
 			break
 		}
 	}
-
-	return g.Get(parentID)
+	result, ok := g.Get(parentID)
+	return result, ok
 }
 
 // GetParentID is a combination of getting the parent the getting the ID.
@@ -193,6 +193,10 @@ func (g *Graph) Disconnect(from, to string) {
 
 // SafeDisconnect disconnects two vertices by IDs but only if valid
 func (g *Graph) SafeDisconnect(from, to string) error {
+	if _, ok := g.GetParentID(to); ok {
+		return errors.New("parent edge removal considered unsafe")
+	}
+
 	g.innerLock.Lock()
 	defer g.innerLock.Unlock()
 

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -523,7 +523,7 @@ func rootFirstWalk(ctx context.Context, g *Graph, cb WalkFunc) error {
 		// make sure all sibling dependencies are finished first
 		var skip bool
 		for _, edge := range g.DownEdges(id) {
-			if _, ok := done[edge.Target().(string)]; AreSiblingIDs(id, edge.Target().(string)) && !ok {
+			if _, ok := done[edge.Target().(string)]; g.AreSiblings(id, edge.Target().(string)) && !ok {
 				logger.WithField("id", id).WithField("target", edge).Debug("still waiting for sibling")
 				todo = append(todo, id)
 				skip = true

--- a/graph/graph_test.go
+++ b/graph/graph_test.go
@@ -504,6 +504,43 @@ func TestParent(t *testing.T) {
 	assert.Equal(t, should, actual)
 }
 
+func TestParentID(t *testing.T) {
+	t.Parallel()
+	t.Run("valid", func(t *testing.T) {
+		parentID := graph.ID("root")
+		childID := graph.ID("root", "child")
+		g := graph.New()
+		g.Add(node.New(parentID, 1))
+		g.Add(node.New(childID, 2))
+		g.ConnectParent(parentID, childID)
+
+		actualParentID, ok := g.GetParentID(childID)
+		require.True(t, ok)
+		assert.Equal(t, parentID, actualParentID)
+	})
+	t.Run("root", func(t *testing.T) {
+		g := graph.New()
+		g.Add(node.New("root", 1))
+		_, ok := g.GetParentID("root")
+		assert.False(t, ok)
+	})
+	t.Run("one-two-three", func(t *testing.T) {
+		g := graph.New()
+		g.Add(node.New("one", 1))
+		g.Add(node.New("two", 2))
+		g.Add(node.New("three", 2))
+		g.Connect("one", "two")
+		g.Connect("one", "three")
+		g.Connect("two", "three")
+		_, ok := g.GetParentID("one")
+		assert.False(t, ok)
+		_, ok = g.GetParentID("two")
+		assert.False(t, ok)
+		_, ok = g.GetParentID("three")
+		assert.False(t, ok)
+	})
+}
+
 func TestRootFirstWalk(t *testing.T) {
 	// the graph should walk nodes root-to-leaf
 	defer logging.HideLogs(t)()

--- a/graph/graph_test.go
+++ b/graph/graph_test.go
@@ -511,7 +511,7 @@ func TestRootFirstWalk(t *testing.T) {
 	g := graph.New()
 	g.Add(node.New("root", nil))
 	g.Add(node.New("root/child", nil))
-	g.Connect("root", "root/child")
+	g.ConnectParent("root", "root/child")
 
 	var out []string
 	assert.NoError(
@@ -537,8 +537,8 @@ func TestRootFirstWalkSiblingDep(t *testing.T) {
 	g.Add(node.New("root/child", nil))
 	g.Add(node.New("root/sibling", nil))
 
-	g.Connect("root", "root/child")
-	g.Connect("root", "root/sibling")
+	g.ConnectParent("root", "root/child")
+	g.ConnectParent("root", "root/sibling")
 	g.Connect("root/child", "root/sibling")
 
 	var out []string

--- a/graph/ids.go
+++ b/graph/ids.go
@@ -34,11 +34,6 @@ func SiblingID(id, sibling string) string {
 	return ID(ParentID(id), sibling)
 }
 
-// AreSiblingIDs checks if two IDs are siblings
-func AreSiblingIDs(a, b string) bool {
-	return ParentID(a) == ParentID(b)
-}
-
 // BaseID is the end of the ID, so "just" the original part
 func BaseID(id string) string {
 	return path.Base(id)

--- a/graph/ids_test.go
+++ b/graph/ids_test.go
@@ -39,18 +39,6 @@ func TestSiblingID(t *testing.T) {
 	assert.Equal(t, "x/z", graph.SiblingID("x/y", "z"))
 }
 
-func TestAreSiblingIDs(t *testing.T) {
-	t.Parallel()
-
-	assert.True(t, graph.AreSiblingIDs("x/y", "x/z"))
-}
-
-func TestAreSiblingIDsNot(t *testing.T) {
-	t.Parallel()
-
-	assert.False(t, graph.AreSiblingIDs("a/b", "x/y"))
-}
-
 func TestBaseID(t *testing.T) {
 	t.Parallel()
 

--- a/graph/ids_test.go
+++ b/graph/ids_test.go
@@ -27,12 +27,6 @@ func TestID(t *testing.T) {
 	assert.Equal(t, "x/y", graph.ID("x", "y"))
 }
 
-func TestParentID(t *testing.T) {
-	t.Parallel()
-
-	assert.Equal(t, "x", graph.ParentID("x/y"))
-}
-
 func TestSiblingID(t *testing.T) {
 	t.Parallel()
 

--- a/graph/merge_duplicates_test.go
+++ b/graph/merge_duplicates_test.go
@@ -50,7 +50,7 @@ func TestMergeDuplicatesMigratesDependencies(t *testing.T) {
 
 	g := baseDupGraph()
 	g.Add(node.New("root/two", 2))
-	g.Connect("root", "root/two")
+	g.ConnectParent("root", "root/two")
 	g.Connect("root/two", "root/first")
 
 	for i := 1; i <= 5; i++ {
@@ -104,8 +104,8 @@ func baseDupGraph() *graph.Graph {
 	g.Add(node.New("root/one", 1))
 	g.Add(node.New("root/first", 1))
 
-	g.Connect("root", "root/one")
-	g.Connect("root", "root/first")
+	g.ConnectParent("root", "root/one")
+	g.ConnectParent("root", "root/first")
 
 	return g
 }

--- a/load/dependencyresolver.go
+++ b/load/dependencyresolver.go
@@ -159,7 +159,7 @@ func getXrefs(g *graph.Graph, id string, node *parse.Node) (out []string, err er
 		if _, ok := nodeRefs[vertex]; !ok {
 			nodeRefs[vertex] = struct{}{}
 			out = append(out, vertex)
-			if peerVertex, ok := getPeerVertex(id, vertex); ok {
+			if peerVertex, ok := getPeerVertex(g, id, vertex); ok {
 				out = append(out, peerVertex)
 			}
 		}
@@ -167,14 +167,14 @@ func getXrefs(g *graph.Graph, id string, node *parse.Node) (out []string, err er
 	return out, err
 }
 
-func getPeerVertex(src, dst string) (string, bool) {
+func getPeerVertex(g *graph.Graph, src, dst string) (string, bool) {
 	if dst == "." || graph.IsRoot(dst) {
 		return "", false
 	}
-	if graph.AreSiblingIDs(src, dst) {
+	if g.AreSiblings(src, dst) {
 		return dst, true
 	}
-	return getPeerVertex(src, graph.ParentID(dst))
+	return getPeerVertex(g, src, graph.ParentID(dst))
 }
 
 func getNearestAncestor(g *graph.Graph, id, node string) (string, bool) {
@@ -339,7 +339,7 @@ func connectIsolatedGroupNodes(ctx context.Context, g *graph.Graph, nodes []*nod
 		if i > 0 {
 			from := meta.ID
 			to := unconnected[i-1].ID
-			if !graph.AreSiblingIDs(from, to) {
+			if !g.AreSiblings(from, to) {
 				from = groupDep(from)
 				to = groupDep(to)
 			}

--- a/render/renderer.go
+++ b/render/renderer.go
@@ -215,7 +215,7 @@ func (r *Renderer) lookup(name string) (string, error) {
 // value may depend on an outer value, but an outer value may not depend on a
 // nested value.
 func validateLookup(g *graph.Graph, src, dst string) bool {
-	if graph.AreSiblingIDs(src, dst) {
+	if g.AreSiblings(src, dst) {
 		return true
 	}
 	if g.IsNibling(src, dst) {


### PR DESCRIPTION
This builds on top of #423 and prevents `SafeDisconnect` from removing parent edges so that conditionals are not moved outside of their branch nodes when grouped.