### PR TITLE
replace "context" with "golang.org/x/net/context"

### DIFF
--- a/apply/apply.go
+++ b/apply/apply.go
@@ -15,7 +15,6 @@
 package apply
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/asteris-llc/converge/executor"
@@ -24,6 +23,7 @@ import (
 	"github.com/asteris-llc/converge/plan"
 	"github.com/asteris-llc/converge/render"
 	"github.com/pkg/errors"
+	"golang.org/x/net/context"
 )
 
 // MkPipelineF is a function to generate a pipeline given an id

--- a/apply/apply_test.go
+++ b/apply/apply_test.go
@@ -15,7 +15,6 @@
 package apply_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/asteris-llc/converge/apply"
@@ -27,6 +26,7 @@ import (
 	"github.com/asteris-llc/converge/resource"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
 )
 
 func TestApplyNoOp(t *testing.T) {

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -15,7 +15,6 @@
 package cmd
 
 import (
-	"context"
 	"errors"
 	"fmt"
 
@@ -27,6 +26,7 @@ import (
 	"github.com/asteris-llc/converge/rpc/pb"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"golang.org/x/net/context"
 )
 
 // applyCmd represents the plan command

--- a/cmd/graceful_exit.go
+++ b/cmd/graceful_exit.go
@@ -15,11 +15,11 @@
 package cmd
 
 import (
-	"context"
 	"os"
 	"os/signal"
 
 	log "github.com/Sirupsen/logrus"
+	"golang.org/x/net/context"
 )
 
 // GracefulExit traps interrupt signals for a graceful exit

--- a/cmd/graph.go
+++ b/cmd/graph.go
@@ -15,7 +15,6 @@
 package cmd
 
 import (
-	"context"
 	"errors"
 	"fmt"
 
@@ -27,6 +26,7 @@ import (
 	"github.com/asteris-llc/converge/rpc/pb"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"golang.org/x/net/context"
 )
 
 // graphCmd represents the graph command

--- a/cmd/healthcheck.go
+++ b/cmd/healthcheck.go
@@ -15,7 +15,6 @@
 package cmd
 
 import (
-	"context"
 	"errors"
 	"fmt"
 
@@ -27,6 +26,7 @@ import (
 	"github.com/asteris-llc/converge/rpc/pb"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"golang.org/x/net/context"
 )
 
 // healthcheckCmd represents the 'healthcheck' command

--- a/cmd/key.go
+++ b/cmd/key.go
@@ -17,7 +17,6 @@ package cmd
 import (
 	"bufio"
 	"bytes"
-	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -30,6 +29,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"golang.org/x/crypto/openpgp"
+	"golang.org/x/net/context"
 )
 
 var keyCmd = &cobra.Command{

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -15,7 +15,6 @@
 package cmd
 
 import (
-	"context"
 	"errors"
 	"fmt"
 
@@ -27,6 +26,7 @@ import (
 	"github.com/asteris-llc/converge/rpc/pb"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"golang.org/x/net/context"
 )
 
 // planCmd represents the plan command

--- a/cmd/rpc.go
+++ b/cmd/rpc.go
@@ -15,7 +15,6 @@
 package cmd
 
 import (
-	"context"
 	"crypto/tls"
 	"encoding/json"
 	"io"
@@ -33,6 +32,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
+	"golang.org/x/net/context"
 )
 
 const (

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -15,7 +15,6 @@
 package cmd
 
 import (
-	"context"
 	"os"
 	"time"
 
@@ -24,6 +23,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"golang.org/x/net/context"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc/grpclog"
 )

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -15,13 +15,13 @@
 package cmd
 
 import (
-	"context"
 	"errors"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/asteris-llc/converge/load"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"golang.org/x/net/context"
 )
 
 // validateCmd represents the validate command

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -15,10 +15,11 @@
 package fetch
 
 import (
-	"context"
 	"fmt"
 	"net/url"
 	"path"
+
+	"golang.org/x/net/context"
 )
 
 // Any fetches a path based on the scheme of the location

--- a/fetch/fetch_test.go
+++ b/fetch/fetch_test.go
@@ -15,11 +15,11 @@
 package fetch_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/asteris-llc/converge/fetch"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/net/context"
 )
 
 func TestAnyBadURL(t *testing.T) {

--- a/fetch/http.go
+++ b/fetch/http.go
@@ -15,10 +15,11 @@
 package fetch
 
 import (
-	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
+
+	"golang.org/x/net/context"
 )
 
 // HTTP fetches content over HTTP

--- a/fetch/http_test.go
+++ b/fetch/http_test.go
@@ -15,7 +15,6 @@
 package fetch_test
 
 import (
-	"context"
 	"path"
 	"testing"
 
@@ -26,6 +25,7 @@ import (
 	"github.com/asteris-llc/converge/helpers/testing/http"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
 )
 
 func TestHTTP(t *testing.T) {

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -15,7 +15,6 @@
 package graph
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"sync"
@@ -26,6 +25,7 @@ import (
 	"github.com/hashicorp/terraform/dag"
 	"github.com/pkg/errors"
 	cmap "github.com/streamrail/concurrent-map"
+	"golang.org/x/net/context"
 )
 
 // WalkFunc is taken by the walking functions

--- a/graph/graph_test.go
+++ b/graph/graph_test.go
@@ -15,7 +15,6 @@
 package graph_test
 
 import (
-	"context"
 	"errors"
 	"math/rand"
 	"sort"
@@ -29,6 +28,7 @@ import (
 	"github.com/asteris-llc/converge/helpers/logging"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
 )
 
 func TestGet(t *testing.T) {

--- a/graph/merge_duplicates.go
+++ b/graph/merge_duplicates.go
@@ -15,13 +15,13 @@
 package graph
 
 import (
-	"context"
 	"strings"
 	"sync"
 
 	"github.com/asteris-llc/converge/graph/node"
 	"github.com/asteris-llc/converge/helpers/logging"
 	"github.com/mitchellh/hashstructure"
+	"golang.org/x/net/context"
 )
 
 // SkipMergeFunc will be used to determine whether or not to merge a node

--- a/graph/merge_duplicates_test.go
+++ b/graph/merge_duplicates_test.go
@@ -15,7 +15,6 @@
 package graph_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/asteris-llc/converge/graph"
@@ -23,6 +22,7 @@ import (
 	"github.com/asteris-llc/converge/helpers/logging"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
 )
 
 func TestMergeDuplicatesRemovesDuplicates(t *testing.T) {

--- a/graph/notifier_test.go
+++ b/graph/notifier_test.go
@@ -15,7 +15,6 @@
 package graph_test
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -23,6 +22,7 @@ import (
 	"github.com/asteris-llc/converge/graph/node"
 	"github.com/asteris-llc/converge/helpers/logging"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/net/context"
 )
 
 func TestNotifyTransform(t *testing.T) {

--- a/healthcheck/healthcheck.go
+++ b/healthcheck/healthcheck.go
@@ -15,12 +15,12 @@
 package healthcheck
 
 import (
-	"context"
 	"errors"
 
 	"github.com/asteris-llc/converge/graph"
 	"github.com/asteris-llc/converge/graph/node"
 	"github.com/asteris-llc/converge/resource"
+	"golang.org/x/net/context"
 )
 
 // Check defines the interface for a health check

--- a/helpers/logging/context.go
+++ b/helpers/logging/context.go
@@ -15,9 +15,8 @@
 package logging
 
 import (
-	"context"
-
 	"github.com/Sirupsen/logrus"
+	"golang.org/x/net/context"
 )
 
 var loggerKey = struct{}{}

--- a/helpers/testing/http/http.go
+++ b/helpers/testing/http/http.go
@@ -15,7 +15,6 @@
 package http
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -26,6 +25,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/asteris-llc/converge/rpc"
+	"golang.org/x/net/context"
 )
 
 // ServeFile constructs a SingleFileServer on a random port, returning that

--- a/load/dependencyresolver.go
+++ b/load/dependencyresolver.go
@@ -15,7 +15,6 @@
 package load
 
 import (
-	"context"
 	"fmt"
 	"io/ioutil"
 	"sort"
@@ -29,6 +28,7 @@ import (
 	"github.com/asteris-llc/converge/render/extensions"
 	"github.com/asteris-llc/converge/render/preprocessor"
 	"github.com/pkg/errors"
+	"golang.org/x/net/context"
 )
 
 type dependencyGenerator func(g *graph.Graph, id string, node *parse.Node) ([]string, error)

--- a/load/dependencyresolver_test.go
+++ b/load/dependencyresolver_test.go
@@ -15,7 +15,6 @@
 package load_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/asteris-llc/converge/graph"
@@ -24,6 +23,7 @@ import (
 	"github.com/asteris-llc/converge/parse"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
 )
 
 // TestDependencyResolverResolvesDependencies tests dependency resolution

--- a/load/load.go
+++ b/load/load.go
@@ -15,10 +15,9 @@
 package load
 
 import (
-	"context"
-
 	"github.com/asteris-llc/converge/graph"
 	"github.com/pkg/errors"
+	"golang.org/x/net/context"
 )
 
 // Load produces a fully-formed graph from the given root

--- a/load/nodes.go
+++ b/load/nodes.go
@@ -16,7 +16,6 @@ package load
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 
 	"github.com/asteris-llc/converge/fetch"
@@ -27,6 +26,7 @@ import (
 	"github.com/asteris-llc/converge/parse"
 	"github.com/asteris-llc/converge/parse/preprocessor/switch"
 	"github.com/pkg/errors"
+	"golang.org/x/net/context"
 )
 
 type source struct {

--- a/load/nodes_test.go
+++ b/load/nodes_test.go
@@ -15,7 +15,6 @@
 package load_test
 
 import (
-	"context"
 	"sort"
 	"testing"
 
@@ -24,6 +23,7 @@ import (
 	"github.com/asteris-llc/converge/load"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
 )
 
 // TestNodesBasic tests loading basic.hcl

--- a/load/resource.go
+++ b/load/resource.go
@@ -15,7 +15,6 @@
 package load
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/asteris-llc/converge/graph"
@@ -41,6 +40,7 @@ import (
 	_ "github.com/asteris-llc/converge/resource/user"
 	_ "github.com/asteris-llc/converge/resource/wait"
 	_ "github.com/asteris-llc/converge/resource/wait/port"
+	"golang.org/x/net/context"
 )
 
 // SetResources loads the resources for each graph node

--- a/load/resource_test.go
+++ b/load/resource_test.go
@@ -15,7 +15,6 @@
 package load_test
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -27,6 +26,7 @@ import (
 	"github.com/asteris-llc/converge/resource"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
 )
 
 func TestSetResourcesTask(t *testing.T) {

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -15,13 +15,13 @@
 package plan
 
 import (
-	"context"
 	"errors"
 	"fmt"
 
 	"github.com/asteris-llc/converge/graph"
 	"github.com/asteris-llc/converge/graph/node"
 	"github.com/asteris-llc/converge/render"
+	"golang.org/x/net/context"
 )
 
 // ErrTreeContainsErrors is a signal value to indicate errors in the graph

--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -15,7 +15,6 @@
 package plan_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/asteris-llc/converge/graph"
@@ -25,6 +24,7 @@ import (
 	"github.com/asteris-llc/converge/plan"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
 )
 
 func TestPlanNoOp(t *testing.T) {

--- a/prettyprinters/prettyprinter.go
+++ b/prettyprinters/prettyprinter.go
@@ -16,9 +16,9 @@ package prettyprinters
 
 import (
 	"bytes"
-	"context"
 
 	"github.com/asteris-llc/converge/graph"
+	"golang.org/x/net/context"
 )
 
 // New creates a new prettyprinter instance from the specified

--- a/prettyprinters/prettyprinter_test.go
+++ b/prettyprinters/prettyprinter_test.go
@@ -15,7 +15,6 @@
 package prettyprinters_test
 
 import (
-	"context"
 	"fmt"
 	"os"
 
@@ -25,6 +24,7 @@ import (
 	"github.com/asteris-llc/converge/prettyprinters"
 	"github.com/asteris-llc/converge/prettyprinters/graphviz"
 	"github.com/asteris-llc/converge/prettyprinters/graphviz/providers"
+	"golang.org/x/net/context"
 )
 
 func Example_usingADefaultProvider() {

--- a/prettyprinters/subgraph_printer.go
+++ b/prettyprinters/subgraph_printer.go
@@ -16,11 +16,11 @@ package prettyprinters
 
 import (
 	"bytes"
-	"context"
 	"errors"
 
 	"github.com/asteris-llc/converge/graph"
 	"github.com/asteris-llc/converge/graph/node"
+	"golang.org/x/net/context"
 )
 
 // Subgraph are treated as a semi-lattice with the root graph as the ⊥ (join)

--- a/render/factory.go
+++ b/render/factory.go
@@ -15,7 +15,6 @@
 package render
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -24,6 +23,7 @@ import (
 	"github.com/asteris-llc/converge/render/extensions"
 	"github.com/asteris-llc/converge/resource"
 	"github.com/asteris-llc/converge/resource/module"
+	"golang.org/x/net/context"
 )
 
 // Factory generates Renderers

--- a/render/render.go
+++ b/render/render.go
@@ -15,7 +15,6 @@
 package render
 
 import (
-	"context"
 	"crypto/rand"
 	"fmt"
 	"reflect"
@@ -27,6 +26,7 @@ import (
 	"github.com/asteris-llc/converge/resource"
 	"github.com/asteris-llc/converge/resource/module"
 	"github.com/pkg/errors"
+	"golang.org/x/net/context"
 )
 
 // Values for rendering

--- a/render/render_test.go
+++ b/render/render_test.go
@@ -15,7 +15,6 @@
 package render_test
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -28,6 +27,7 @@ import (
 	"github.com/asteris-llc/converge/resource/param"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
 )
 
 func TestRenderSingleNode(t *testing.T) {

--- a/rpc/authorizer.go
+++ b/rpc/authorizer.go
@@ -15,9 +15,9 @@
 package rpc
 
 import (
-	"context"
 	"strings"
 
+	"golang.org/x/net/context"
 	"google.golang.org/grpc/metadata"
 )
 

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -15,10 +15,10 @@
 package rpc
 
 import (
-	"context"
 	"crypto/tls"
 
 	"github.com/asteris-llc/converge/rpc/pb"
+	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 )

--- a/rpc/executor.go
+++ b/rpc/executor.go
@@ -15,7 +15,6 @@
 package rpc
 
 import (
-	"context"
 	"encoding/json"
 
 	"google.golang.org/grpc/metadata"
@@ -28,6 +27,7 @@ import (
 	"github.com/asteris-llc/converge/prettyprinters/human"
 	"github.com/asteris-llc/converge/rpc/pb"
 	"github.com/pkg/errors"
+	"golang.org/x/net/context"
 )
 
 var (

--- a/rpc/grapher_test.go
+++ b/rpc/grapher_test.go
@@ -15,7 +15,6 @@
 package rpc
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -27,6 +26,7 @@ import (
 	"github.com/fgrid/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"golang.org/x/net/context"
 )
 
 func TestGrapherGraph(t *testing.T) {

--- a/rpc/grapherclient.go
+++ b/rpc/grapherclient.go
@@ -15,13 +15,13 @@
 package rpc
 
 import (
-	"context"
 	"io"
 
 	"github.com/asteris-llc/converge/graph"
 	"github.com/asteris-llc/converge/graph/node"
 	"github.com/asteris-llc/converge/rpc/pb"
 	"github.com/pkg/errors"
+	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 )
 

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -15,10 +15,10 @@
 package rpc
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/braintree/manners"
+	"golang.org/x/net/context"
 )
 
 // ContextServer is a Server controlled by a context for stopping gracefully

--- a/rpc/http_test.go
+++ b/rpc/http_test.go
@@ -15,7 +15,6 @@
 package rpc_test
 
 import (
-	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -26,6 +25,7 @@ import (
 	"github.com/asteris-llc/converge/rpc"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
 )
 
 func testServeFunc(w http.ResponseWriter, r *http.Request) {

--- a/rpc/jwt_test.go
+++ b/rpc/jwt_test.go
@@ -15,7 +15,6 @@
 package rpc_test
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -25,6 +24,7 @@ import (
 	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
 )
 
 func TestJWTAuth(t *testing.T) {

--- a/rpc/logging.go
+++ b/rpc/logging.go
@@ -15,11 +15,10 @@
 package rpc
 
 import (
-	"context"
-
 	"github.com/Sirupsen/logrus"
 	"github.com/asteris-llc/converge/helpers/logging"
 	"github.com/fgrid/uuid"
+	"golang.org/x/net/context"
 )
 
 func getLogger(ctx context.Context) *logrus.Entry {

--- a/rpc/pb/loadrequest.go
+++ b/rpc/pb/loadrequest.go
@@ -15,14 +15,13 @@
 package pb
 
 import (
-	"context"
-
 	"github.com/asteris-llc/converge/graph"
 	"github.com/asteris-llc/converge/helpers/logging"
 	"github.com/asteris-llc/converge/load"
 	"github.com/asteris-llc/converge/render"
 	"github.com/asteris-llc/converge/transform"
 	"github.com/pkg/errors"
+	"golang.org/x/net/context"
 )
 
 // Load gets a graph from a LocationRequest

--- a/rpc/rest.go
+++ b/rpc/rest.go
@@ -15,11 +15,11 @@
 package rpc
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/asteris-llc/converge/rpc/pb"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+	"golang.org/x/net/context"
 )
 
 func restGatewayMux(ctx context.Context, addr string, opts *ClientOpts) (http.Handler, error) {

--- a/transform/control.go
+++ b/transform/control.go
@@ -15,7 +15,6 @@
 package transform
 
 import (
-	"context"
 	"crypto/rand"
 	"errors"
 
@@ -26,6 +25,7 @@ import (
 	"github.com/asteris-llc/converge/parse/preprocessor/switch"
 	"github.com/asteris-llc/converge/render"
 	"github.com/asteris-llc/converge/resource"
+	"golang.org/x/net/context"
 )
 
 // ResolveConditionals will walk the graph and wrap tasks whose parent is a case


### PR DESCRIPTION
dependencies (specifically go-rpc) depend on "golang.org/x/net/context" and are not compatible with "context"

fixes #318
