### PR TITLE
makefile: add hashes to files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,13 +100,14 @@ xcompile: rpc/pb/root.pb.go rpc/pb/root.pb.gw.go test
 		-os="freebsd" \
 		-os="solaris" \
 		-output="build/$(NAME)_$(shell git describe)_{{.OS}}_{{.Arch}}/$(NAME)"
+	find build -type file -execdir /bin/bash -c 'shasum -a 256 $$0 > $$0.sha256sum' \{\} \;
 
 package: xcompile
 	@mkdir -p build/tgz
 	for f in $(shell find build -name converge | cut -d/ -f2); do \
-	  (cd $(shell pwd)/build/$$f && tar -zcvf ../tgz/$$f.tar.gz converge); \
-    echo $$f; \
-  done
+		(cd $(shell pwd)/build/$$f && tar -zcvf ../tgz/$$f.tar.gz *); \
+	done
+	(cd build/tgz; shasum -a 512 * > tgz.sha256sum)
 
 rpc/pb/root.pb.go: rpc/pb/root.proto
 	protoc -I rpc/pb \


### PR DESCRIPTION
Add hashes to files. This ends with a directory structure like:

```
build
├── converge_0.3.0-rc1_darwin_386
│   ├── converge
│   └── converge.sha256sum
├── converge_0.3.0-rc1_darwin_amd64
│   ├── converge
│   └── converge.sha256sum
├── converge_0.3.0-rc1_freebsd_386
│   ├── converge
│   └── converge.sha256sum
├── converge_0.3.0-rc1_freebsd_amd64
│   ├── converge
│   └── converge.sha256sum
├── converge_0.3.0-rc1_freebsd_arm
│   ├── converge
│   └── converge.sha256sum
├── converge_0.3.0-rc1_linux_386
│   ├── converge
│   └── converge.sha256sum
├── converge_0.3.0-rc1_linux_amd64
│   ├── converge
│   └── converge.sha256sum
├── converge_0.3.0-rc1_linux_arm
│   ├── converge
│   └── converge.sha256sum
├── converge_0.3.0-rc1_linux_arm64
│   ├── converge
│   └── converge.sha256sum
├── converge_0.3.0-rc1_linux_ppc64
│   ├── converge
│   └── converge.sha256sum
├── converge_0.3.0-rc1_linux_ppc64le
│   ├── converge
│   └── converge.sha256sum
├── converge_0.3.0-rc1_solaris_amd64
│   ├── converge
│   └── converge.sha256sum
└── tgz
    ├── converge_0.3.0-rc1_darwin_386.tar.gz
    ├── converge_0.3.0-rc1_darwin_amd64.tar.gz
    ├── converge_0.3.0-rc1_freebsd_386.tar.gz
    ├── converge_0.3.0-rc1_freebsd_amd64.tar.gz
    ├── converge_0.3.0-rc1_freebsd_arm.tar.gz
    ├── converge_0.3.0-rc1_linux_386.tar.gz
    ├── converge_0.3.0-rc1_linux_amd64.tar.gz
    ├── converge_0.3.0-rc1_linux_arm.tar.gz
    ├── converge_0.3.0-rc1_linux_arm64.tar.gz
    ├── converge_0.3.0-rc1_linux_ppc64.tar.gz
    ├── converge_0.3.0-rc1_linux_ppc64le.tar.gz
    ├── converge_0.3.0-rc1_solaris_amd64.tar.gz
    └── tgz.sha256sum

13 directories, 37 files
```