### PR TITLE
Fix/resource duplication

### DIFF
--- a/load/nodes.go
+++ b/load/nodes.go
@@ -97,7 +97,7 @@ func Nodes(ctx context.Context, root string, verify bool) (*graph.Graph, error) 
 				}
 				continue
 			}
-			newID := graph.ID(current.Parent, resource.String())
+			newID := graph.ID(current.Parent, resource.ID())
 			out.Add(node.New(newID, resource))
 			out.ConnectParent(current.Parent, newID)
 
@@ -133,7 +133,7 @@ func expandSwitchMacro(data []byte, current *source, n *parse.Node, g *graph.Gra
 	if err != nil {
 		return g, err
 	}
-	switchID := graph.ID(current.Parent, switchNode.String())
+	switchID := graph.ID(current.Parent, switchNode.ID())
 	g.Add(node.New(switchID, switchNode))
 	g.ConnectParent(current.Parent, switchID)
 	for _, branch := range switchObj.Branches {
@@ -141,14 +141,14 @@ func expandSwitchMacro(data []byte, current *source, n *parse.Node, g *graph.Gra
 		if err != nil {
 			return g, err
 		}
-		branchID := graph.ID(switchID, branchNode.String())
+		branchID := graph.ID(switchID, branchNode.ID())
 		g.Add(node.New(branchID, branchNode))
 		g.ConnectParent(switchID, branchID)
 		for _, innerNode := range branch.InnerNodes {
 			if err := validateInnerNode(innerNode); err != nil {
 				return g, err
 			}
-			innerID := graph.ID(branchID, innerNode.String())
+			innerID := graph.ID(branchID, innerNode.ID())
 			g.Add(node.New(innerID, innerNode))
 			g.ConnectParent(branchID, innerID)
 		}

--- a/parse/node.go
+++ b/parse/node.go
@@ -251,10 +251,16 @@ func (n *Node) badTypeError(key, typ string, val interface{}) error {
 	)
 }
 
-func (n *Node) String() string {
+// ID formats and returns the node ID as kind.name
+func (n *Node) ID() string {
 	return fmt.Sprintf(
 		"%s.%s",
 		n.Kind(),
 		n.Name(),
 	)
+}
+
+// String returns the node ID
+func (n *Node) String() string {
+	return n.ID()
 }

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -15,6 +15,8 @@
 package parse
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/hcl"
 	"github.com/hashicorp/hcl/hcl/ast"
@@ -40,6 +42,12 @@ func Parse(content []byte) (resources []*Node, err error) {
 			return n, false
 		}
 
+		for _, v := range resources {
+			if v.ID() == item.ID() {
+				err = multierror.Append(fmt.Errorf("duplicate resource %s", item.ID()))
+				return n, false
+			}
+		}
 		resources = append(resources, item)
 
 		return n, false

--- a/samples/errors/duplicate_resource.hcl
+++ b/samples/errors/duplicate_resource.hcl
@@ -1,0 +1,9 @@
+task "a" {
+   check = "[[ -d /tmp/a ]]"
+   apply = "mkdir /tmp/a"
+}
+
+task "a" {
+   check = "[[ -d /tmp/b ]]"
+   apply = "mkdir /tmp/b"
+}


### PR DESCRIPTION
Check hcl for duplicate resources during parse, then return an error.
samples/errors/duplicate-resource.hcl