### PR TITLE
Feature/preparer time.duration

### DIFF
--- a/docs/content/license.md
+++ b/docs/content/license.md
@@ -1,6 +1,6 @@
 ---
 title: "License"
-date: "2016-08-24T16:29:08-05:00"
+date: "2016-11-07T13:35:24-06:00"
 menu:
   main:
     weight: 10

--- a/docs/content/resource-authors-guide.md
+++ b/docs/content/resource-authors-guide.md
@@ -165,12 +165,6 @@ If the user provides a zero, the value will be `*0`. Otherwise, it wil be `nil`.
 Other than `hcl` (which is used to specify the field name you'll accept) the
 following struct tags control the values you get:
 
-- `doc_type`: control the exact printed type in the documentation. Example:
-  fields that accept
-  a [duration string](https://golang.org/pkg/time/#ParseDuration) (such
-  as [task.timeout]({{< ref "resources/task.md" >}})) are commonly strings
-  with a `doc_type` of "duration string"
-
 - `base`: used with numeric types to indicate a base for parsing. Does not work
   with floats. Example: [file.mode]({{< ref "resources/file.mode.md" >}})
   needs an octal number, and specifies that in this tag.

--- a/docs/content/resources/docker.container.md
+++ b/docs/content/resources/docker.container.md
@@ -1,7 +1,7 @@
 ---
 title: "docker.container"
 slug: "docker-container"
-date: "2016-10-04T13:01:49-05:00"
+date: "2016-11-07T13:35:27-06:00"
 menu:
   main:
     parent: resources

--- a/docs/content/resources/docker.container.md
+++ b/docs/content/resources/docker.container.md
@@ -1,7 +1,7 @@
 ---
 title: "docker.container"
 slug: "docker-container"
-date: "2016-11-07T13:35:27-06:00"
+date: "2016-11-09T14:19:17-06:00"
 menu:
   main:
     parent: resources

--- a/docs/content/resources/docker.image.md
+++ b/docs/content/resources/docker.image.md
@@ -1,7 +1,7 @@
 ---
 title: "docker.image"
 slug: "docker-image"
-date: "2016-10-04T13:01:49-05:00"
+date: "2016-11-07T13:35:28-06:00"
 menu:
   main:
     parent: resources
@@ -34,12 +34,16 @@ docker.image "busybox" {
 
   tag of the image to pull
 
-- `inactivity_timeout` (duration_string)
+- `inactivity_timeout` (duration)
 
   the amount of time to wait after a period of inactivity. The timeout is
-reset each time new data arrives. The format is Go's duration string. A
-duration string is a possibly signed sequence of decimal numbers, each with
-optional fraction and a unit suffix, such as "300ms", "-1.5h" or "2h45m".
-Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+reset each time new data arrives.
+
+Acceptable formats are a number in nanoseconds or a duration string. A Duration
+represents the elapsed time between two instants as an int64 nanosecond count.
+The representation limits the largest representable duration to approximately
+290 years. A duration string is a possibly signed sequence of decimal numbers,
+each with optional fraction and a unit suffix, such as "300ms", "-1.5h" or
+"2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 
 

--- a/docs/content/resources/docker.image.md
+++ b/docs/content/resources/docker.image.md
@@ -1,7 +1,7 @@
 ---
 title: "docker.image"
 slug: "docker-image"
-date: "2016-11-07T13:35:28-06:00"
+date: "2016-11-09T14:19:17-06:00"
 menu:
   main:
     parent: resources
@@ -39,8 +39,8 @@ docker.image "busybox" {
   the amount of time to wait after a period of inactivity. The timeout is
 reset each time new data arrives.
 
-Acceptable formats are a number in nanoseconds or a duration string. A Duration
-represents the elapsed time between two instants as an int64 nanosecond count.
+Acceptable formats are a number in seconds or a duration string. A Duration
+represents the elapsed time between two instants as an int64 second count.
 The representation limits the largest representable duration to approximately
 290 years. A duration string is a possibly signed sequence of decimal numbers,
 each with optional fraction and a unit suffix, such as "300ms", "-1.5h" or

--- a/docs/content/resources/docker.network.md
+++ b/docs/content/resources/docker.network.md
@@ -1,7 +1,7 @@
 ---
 title: "docker.network"
 slug: "docker-network"
-date: "2016-11-04T08:35:32-04:00"
+date: "2016-11-09T14:19:17-06:00"
 menu:
   main:
     parent: resources

--- a/docs/content/resources/docker.volume.md
+++ b/docs/content/resources/docker.volume.md
@@ -1,7 +1,7 @@
 ---
 title: "docker.volume"
 slug: "docker-volume"
-date: "2016-10-31T11:55:27-04:00"
+date: "2016-11-09T14:19:17-06:00"
 menu:
   main:
     parent: resources

--- a/docs/content/resources/file.content.md
+++ b/docs/content/resources/file.content.md
@@ -1,7 +1,7 @@
 ---
 title: "file.content"
 slug: "file-content"
-date: "2016-10-04T13:01:49-05:00"
+date: "2016-11-07T13:35:30-06:00"
 menu:
   main:
     parent: resources

--- a/docs/content/resources/file.content.md
+++ b/docs/content/resources/file.content.md
@@ -1,7 +1,7 @@
 ---
 title: "file.content"
 slug: "file-content"
-date: "2016-11-07T13:35:30-06:00"
+date: "2016-11-09T14:19:17-06:00"
 menu:
   main:
     parent: resources

--- a/docs/content/resources/file.directory.md
+++ b/docs/content/resources/file.directory.md
@@ -1,7 +1,7 @@
 ---
 title: "file.directory"
 slug: "file-directory"
-date: "2016-11-07T13:35:31-06:00"
+date: "2016-11-09T14:19:17-06:00"
 menu:
   main:
     parent: resources

--- a/docs/content/resources/file.directory.md
+++ b/docs/content/resources/file.directory.md
@@ -1,7 +1,7 @@
 ---
 title: "file.directory"
 slug: "file-directory"
-date: "2016-10-04T13:01:49-05:00"
+date: "2016-11-07T13:35:31-06:00"
 menu:
   main:
     parent: resources

--- a/docs/content/resources/file.mode.md
+++ b/docs/content/resources/file.mode.md
@@ -1,7 +1,7 @@
 ---
 title: "file.mode"
 slug: "file-mode"
-date: "2016-10-04T13:01:49-05:00"
+date: "2016-11-07T13:35:32-06:00"
 menu:
   main:
     parent: resources

--- a/docs/content/resources/file.mode.md
+++ b/docs/content/resources/file.mode.md
@@ -1,7 +1,7 @@
 ---
 title: "file.mode"
 slug: "file-mode"
-date: "2016-11-07T13:35:32-06:00"
+date: "2016-11-09T14:19:17-06:00"
 menu:
   main:
     parent: resources

--- a/docs/content/resources/module.md
+++ b/docs/content/resources/module.md
@@ -1,7 +1,7 @@
 ---
 title: "module"
 slug: "module"
-date: "2016-11-07T13:35:33-06:00"
+date: "2016-11-09T14:19:17-06:00"
 menu:
   main:
     parent: resources

--- a/docs/content/resources/module.md
+++ b/docs/content/resources/module.md
@@ -1,7 +1,7 @@
 ---
 title: "module"
 slug: "module"
-date: "2016-10-04T13:01:49-05:00"
+date: "2016-11-07T13:35:33-06:00"
 menu:
   main:
     parent: resources

--- a/docs/content/resources/package.rpm.md
+++ b/docs/content/resources/package.rpm.md
@@ -1,7 +1,7 @@
 ---
 title: "package.rpm"
 slug: "package-rpm"
-date: "2016-11-07T13:35:34-06:00"
+date: "2016-11-09T14:19:18-06:00"
 menu:
   main:
     parent: resources

--- a/docs/content/resources/package.rpm.md
+++ b/docs/content/resources/package.rpm.md
@@ -1,7 +1,7 @@
 ---
 title: "package.rpm"
 slug: "package-rpm"
-date: "2016-10-19T08:54:35-05:00"
+date: "2016-11-07T13:35:34-06:00"
 menu:
   main:
     parent: resources

--- a/docs/content/resources/param.md
+++ b/docs/content/resources/param.md
@@ -1,7 +1,7 @@
 ---
 title: "param"
 slug: "param"
-date: "2016-10-04T13:01:49-05:00"
+date: "2016-11-07T13:35:36-06:00"
 menu:
   main:
     parent: resources

--- a/docs/content/resources/param.md
+++ b/docs/content/resources/param.md
@@ -1,7 +1,7 @@
 ---
 title: "param"
 slug: "param"
-date: "2016-11-07T13:35:36-06:00"
+date: "2016-11-09T14:19:18-06:00"
 menu:
   main:
     parent: resources

--- a/docs/content/resources/task.md
+++ b/docs/content/resources/task.md
@@ -1,7 +1,7 @@
 ---
 title: "task"
 slug: "task"
-date: "2016-10-04T13:01:49-05:00"
+date: "2016-11-07T13:35:37-06:00"
 menu:
   main:
     parent: resources
@@ -59,13 +59,16 @@ exit with exit code 0 if the resource does not need to be changed, and
 expectations apply (that is, exit code 0 for success, 1 or above for
 failure.)
 
-- `timeout` (duration string)
+- `timeout` (duration)
 
-  the amount of time the command will wait before halting forcefully. The
-format is Go's duration string. A duration string is a possibly signed
-sequence of decimal numbers, each with optional fraction and a unit
-suffix, such as "300ms", "-1.5h" or "2h45m". Valid time units are "ns",
-"us" (or "µs"), "ms", "s", "m", "h".
+  the amount of time the command will wait before halting forcefully.
+
+Acceptable formats are a number in nanoseconds or a duration string. A Duration
+represents the elapsed time between two instants as an int64 nanosecond count.
+The representation limits the largest representable duration to approximately
+290 years. A duration string is a possibly signed sequence of decimal numbers,
+each with optional fraction and a unit suffix, such as "300ms", "-1.5h" or
+"2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 
 - `dir` (string)
 

--- a/docs/content/resources/task.md
+++ b/docs/content/resources/task.md
@@ -1,7 +1,7 @@
 ---
 title: "task"
 slug: "task"
-date: "2016-11-07T13:35:37-06:00"
+date: "2016-11-09T14:19:18-06:00"
 menu:
   main:
     parent: resources
@@ -59,12 +59,12 @@ exit with exit code 0 if the resource does not need to be changed, and
 expectations apply (that is, exit code 0 for success, 1 or above for
 failure.)
 
-- `timeout` (duration)
+- `timeout` (optional duration)
 
   the amount of time the command will wait before halting forcefully.
 
-Acceptable formats are a number in nanoseconds or a duration string. A Duration
-represents the elapsed time between two instants as an int64 nanosecond count.
+Acceptable formats are a number in seconds or a duration string. A Duration
+represents the elapsed time between two instants as an int64 second count.
 The representation limits the largest representable duration to approximately
 290 years. A duration string is a possibly signed sequence of decimal numbers,
 each with optional fraction and a unit suffix, such as "300ms", "-1.5h" or

--- a/docs/content/resources/task.query.md
+++ b/docs/content/resources/task.query.md
@@ -1,7 +1,7 @@
 ---
 title: "task.query"
 slug: "task-query"
-date: "2016-11-07T13:35:38-06:00"
+date: "2016-11-09T14:19:18-06:00"
 menu:
   main:
     parent: resources
@@ -39,11 +39,11 @@ file.content "hostname data" {
 - `exec_flags` (list of strings)
 
 
-- `timeout` (duration)
+- `timeout` (optional duration)
 
   
-Acceptable formats are a number in nanoseconds or a duration string. A Duration
-represents the elapsed time between two instants as an int64 nanosecond count.
+Acceptable formats are a number in seconds or a duration string. A Duration
+represents the elapsed time between two instants as an int64 second count.
 The representation limits the largest representable duration to approximately
 290 years. A duration string is a possibly signed sequence of decimal numbers,
 each with optional fraction and a unit suffix, such as "300ms", "-1.5h" or

--- a/docs/content/resources/task.query.md
+++ b/docs/content/resources/task.query.md
@@ -1,7 +1,7 @@
 ---
 title: "task.query"
 slug: "task-query"
-date: "2016-10-04T13:01:49-05:00"
+date: "2016-11-07T13:35:38-06:00"
 menu:
   main:
     parent: resources
@@ -39,8 +39,15 @@ file.content "hostname data" {
 - `exec_flags` (list of strings)
 
 
-- `timeout` (duration string)
+- `timeout` (duration)
 
+  
+Acceptable formats are a number in nanoseconds or a duration string. A Duration
+represents the elapsed time between two instants as an int64 nanosecond count.
+The representation limits the largest representable duration to approximately
+290 years. A duration string is a possibly signed sequence of decimal numbers,
+each with optional fraction and a unit suffix, such as "300ms", "-1.5h" or
+"2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 
 - `dir` (string)
 

--- a/docs/content/resources/user.group.md
+++ b/docs/content/resources/user.group.md
@@ -1,7 +1,7 @@
 ---
 title: "user.group"
 slug: "user-group"
-date: "2016-11-07T13:35:39-06:00"
+date: "2016-11-09T14:19:18-06:00"
 menu:
   main:
     parent: resources

--- a/docs/content/resources/user.group.md
+++ b/docs/content/resources/user.group.md
@@ -1,7 +1,7 @@
 ---
 title: "user.group"
 slug: "user-group"
-date: "2016-10-28T08:47:08-05:00"
+date: "2016-11-07T13:35:39-06:00"
 menu:
   main:
     parent: resources

--- a/docs/content/resources/user.user.md
+++ b/docs/content/resources/user.user.md
@@ -1,7 +1,7 @@
 ---
 title: "user.user"
 slug: "user-user"
-date: "2016-10-28T08:47:08-05:00"
+date: "2016-11-07T13:35:40-06:00"
 menu:
   main:
     parent: resources

--- a/docs/content/resources/user.user.md
+++ b/docs/content/resources/user.user.md
@@ -1,7 +1,7 @@
 ---
 title: "user.user"
 slug: "user-user"
-date: "2016-11-07T13:35:40-06:00"
+date: "2016-11-09T14:19:18-06:00"
 menu:
   main:
     parent: resources

--- a/docs/content/resources/wait.port.md
+++ b/docs/content/resources/wait.port.md
@@ -1,7 +1,7 @@
 ---
 title: "wait.port"
 slug: "wait-port"
-date: "2016-10-03T10:23:34-04:00"
+date: "2016-11-07T13:35:43-06:00"
 menu:
   main:
     parent: resources
@@ -35,24 +35,32 @@ and the specified Port.
 
   the TCP port to attempt to connect to.
 
-- `interval` (duration string)
+- `interval` (optional duration)
 
-  the amount of time to wait in between checks. The format is Go's duration
-string. A duration string is a possibly signed sequence of decimal numbers,
+  the amount of time to wait in between checks. If the interval is not
+specified, it will default to 5 seconds.
+
+Acceptable formats are a number in nanoseconds or a duration string. A Duration
+represents the elapsed time between two instants as an int64 nanosecond count.
+The representation limits the largest representable duration to approximately
+290 years. A duration string is a possibly signed sequence of decimal numbers,
 each with optional fraction and a unit suffix, such as "300ms", "-1.5h" or
-"2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h". If
-the interval is not specified, it will default to 5 seconds.
+"2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 
-- `grace_period` (duration string)
+- `grace_period` (optional duration)
 
   the amount of time to wait before running the first check and after a
-successful check. The format is Go's duration string. A duration string is
-a possibly signed sequence of decimal numbers, each with optional fraction
-and a unit suffix, such as "300ms", "-1.5h" or "2h45m". Valid time units
-are "ns", "us" (or "µs"), "ms", "s", "m", "h". If no grace period is
-specified, no grace period will be taken into account.
+successful check. If no grace period is specified, no grace period will be
+taken into account.
 
-- `max_retry` (int)
+Acceptable formats are a number in nanoseconds or a duration string. A Duration
+represents the elapsed time between two instants as an int64 nanosecond count.
+The representation limits the largest representable duration to approximately
+290 years. A duration string is a possibly signed sequence of decimal numbers,
+each with optional fraction and a unit suffix, such as "300ms", "-1.5h" or
+"2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+
+- `max_retry` (optional int)
 
   the maximum number of attempts before the wait fails. If the maximum number
 of retries is not set, it will default to 5.

--- a/docs/content/resources/wait.port.md
+++ b/docs/content/resources/wait.port.md
@@ -1,7 +1,7 @@
 ---
 title: "wait.port"
 slug: "wait-port"
-date: "2016-11-07T13:35:43-06:00"
+date: "2016-11-09T14:19:18-06:00"
 menu:
   main:
     parent: resources
@@ -40,8 +40,8 @@ and the specified Port.
   the amount of time to wait in between checks. If the interval is not
 specified, it will default to 5 seconds.
 
-Acceptable formats are a number in nanoseconds or a duration string. A Duration
-represents the elapsed time between two instants as an int64 nanosecond count.
+Acceptable formats are a number in seconds or a duration string. A Duration
+represents the elapsed time between two instants as an int64 second count.
 The representation limits the largest representable duration to approximately
 290 years. A duration string is a possibly signed sequence of decimal numbers,
 each with optional fraction and a unit suffix, such as "300ms", "-1.5h" or
@@ -53,8 +53,8 @@ each with optional fraction and a unit suffix, such as "300ms", "-1.5h" or
 successful check. If no grace period is specified, no grace period will be
 taken into account.
 
-Acceptable formats are a number in nanoseconds or a duration string. A Duration
-represents the elapsed time between two instants as an int64 nanosecond count.
+Acceptable formats are a number in seconds or a duration string. A Duration
+represents the elapsed time between two instants as an int64 second count.
 The representation limits the largest representable duration to approximately
 290 years. A duration string is a possibly signed sequence of decimal numbers,
 each with optional fraction and a unit suffix, such as "300ms", "-1.5h" or

--- a/docs/content/resources/wait.query.md
+++ b/docs/content/resources/wait.query.md
@@ -1,7 +1,7 @@
 ---
 title: "wait.query"
 slug: "wait-query"
-date: "2016-10-03T10:23:34-04:00"
+date: "2016-11-07T13:35:42-06:00"
 menu:
   main:
     parent: resources
@@ -44,13 +44,16 @@ the resource is healthy, and 1 (or above) otherwise.
 
   flags to pass to the interpreter at execution time.
 
-- `timeout` (duration string)
+- `timeout` (duration)
 
-  the amount of time the command will wait before halting forcefully. The
-format is Go's duration string. A duration string is a possibly signed
-sequence of decimal numbers, each with optional fraction and a unit
-suffix, such as "300ms", "-1.5h" or "2h45m". Valid time units are "ns",
-"us" (or "µs"), "ms", "s", "m", "h".
+  the amount of time the command will wait before halting forcefully.
+
+Acceptable formats are a number in nanoseconds or a duration string. A Duration
+represents the elapsed time between two instants as an int64 nanosecond count.
+The representation limits the largest representable duration to approximately
+290 years. A duration string is a possibly signed sequence of decimal numbers,
+each with optional fraction and a unit suffix, such as "300ms", "-1.5h" or
+"2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 
 - `dir` (string)
 
@@ -60,24 +63,32 @@ suffix, such as "300ms", "-1.5h" or "2h45m". Valid time units are "ns",
 
   any environment variables that should be passed to the command.
 
-- `interval` (duration string)
+- `interval` (optional duration)
 
-  the amount of time to wait in between checks. The format is Go's duration
-string. A duration string is a possibly signed sequence of decimal numbers,
+  the amount of time to wait in between checks. If the interval is not
+specified, it will default to 5 seconds.
+
+Acceptable formats are a number in nanoseconds or a duration string. A Duration
+represents the elapsed time between two instants as an int64 nanosecond count.
+The representation limits the largest representable duration to approximately
+290 years. A duration string is a possibly signed sequence of decimal numbers,
 each with optional fraction and a unit suffix, such as "300ms", "-1.5h" or
-"2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h". If
-the interval is not specified, it will default to 5 seconds.
+"2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 
-- `grace_period` (duration string)
+- `grace_period` (optional duration)
 
   the amount of time to wait before running the first check and after a
-successful check. The format is Go's duration string. A duration string is
-a possibly signed sequence of decimal numbers, each with optional fraction
-and a unit suffix, such as "300ms", "-1.5h" or "2h45m". Valid time units
-are "ns", "us" (or "µs"), "ms", "s", "m", "h". If no grace period is
-specified, no grace period will be taken into account.
+successful check. If no grace period is specified, no grace period will be
+taken into account.
 
-- `max_retry` (int)
+Acceptable formats are a number in nanoseconds or a duration string. A Duration
+represents the elapsed time between two instants as an int64 nanosecond count.
+The representation limits the largest representable duration to approximately
+290 years. A duration string is a possibly signed sequence of decimal numbers,
+each with optional fraction and a unit suffix, such as "300ms", "-1.5h" or
+"2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+
+- `max_retry` (optional int)
 
   the maximum number of attempts before the wait fails. If the maximum number
 of retries is not set, it will default to 5.

--- a/docs/content/resources/wait.query.md
+++ b/docs/content/resources/wait.query.md
@@ -1,7 +1,7 @@
 ---
 title: "wait.query"
 slug: "wait-query"
-date: "2016-11-07T13:35:42-06:00"
+date: "2016-11-09T14:19:18-06:00"
 menu:
   main:
     parent: resources
@@ -44,12 +44,12 @@ the resource is healthy, and 1 (or above) otherwise.
 
   flags to pass to the interpreter at execution time.
 
-- `timeout` (duration)
+- `timeout` (optional duration)
 
   the amount of time the command will wait before halting forcefully.
 
-Acceptable formats are a number in nanoseconds or a duration string. A Duration
-represents the elapsed time between two instants as an int64 nanosecond count.
+Acceptable formats are a number in seconds or a duration string. A Duration
+represents the elapsed time between two instants as an int64 second count.
 The representation limits the largest representable duration to approximately
 290 years. A duration string is a possibly signed sequence of decimal numbers,
 each with optional fraction and a unit suffix, such as "300ms", "-1.5h" or
@@ -68,8 +68,8 @@ each with optional fraction and a unit suffix, such as "300ms", "-1.5h" or
   the amount of time to wait in between checks. If the interval is not
 specified, it will default to 5 seconds.
 
-Acceptable formats are a number in nanoseconds or a duration string. A Duration
-represents the elapsed time between two instants as an int64 nanosecond count.
+Acceptable formats are a number in seconds or a duration string. A Duration
+represents the elapsed time between two instants as an int64 second count.
 The representation limits the largest representable duration to approximately
 290 years. A duration string is a possibly signed sequence of decimal numbers,
 each with optional fraction and a unit suffix, such as "300ms", "-1.5h" or
@@ -81,8 +81,8 @@ each with optional fraction and a unit suffix, such as "300ms", "-1.5h" or
 successful check. If no grace period is specified, no grace period will be
 taken into account.
 
-Acceptable formats are a number in nanoseconds or a duration string. A Duration
-represents the elapsed time between two instants as an int64 nanosecond count.
+Acceptable formats are a number in seconds or a duration string. A Duration
+represents the elapsed time between two instants as an int64 second count.
 The representation limits the largest representable duration to approximately
 290 years. A duration string is a possibly signed sequence of decimal numbers,
 each with optional fraction and a unit suffix, such as "300ms", "-1.5h" or

--- a/docs/extract.go
+++ b/docs/extract.go
@@ -299,7 +299,7 @@ func stringify(node ast.Expr) string {
 		case "resource.Value":
 			return "anything"
 		default:
-			return fmt.Sprintf("%T", n)
+			return selExp
 		}
 
 	default:

--- a/docs/extract.go
+++ b/docs/extract.go
@@ -31,8 +31,8 @@ import (
 )
 
 const durationComment = `
-Acceptable formats are a number in nanoseconds or a duration string. A Duration
-represents the elapsed time between two instants as an int64 nanosecond count.
+Acceptable formats are a number in seconds or a duration string. A Duration
+represents the elapsed time between two instants as an int64 second count.
 The representation limits the largest representable duration to approximately
 290 years. A duration string is a possibly signed sequence of decimal numbers,
 each with optional fraction and a unit suffix, such as "300ms", "-1.5h" or
@@ -294,6 +294,8 @@ func stringify(node ast.Expr) string {
 		switch selExp {
 		case "time.Duration":
 			return "duration"
+		case "pkg.State":
+			return "State"
 		case "resource.Value":
 			return "anything"
 		default:

--- a/resource/docker/image/preparer.go
+++ b/resource/docker/image/preparer.go
@@ -39,28 +39,17 @@ type Preparer struct {
 	// duration string is a possibly signed sequence of decimal numbers, each with
 	// optional fraction and a unit suffix, such as "300ms", "-1.5h" or "2h45m".
 	// Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
-	InactivityTimeout string `hcl:"inactivity_timeout" doc_type:"duration_string"`
+	InactivityTimeout time.Duration `hcl:"inactivity_timeout"`
 }
 
 // Prepare a new docker image
 func (p *Preparer) Prepare(ctx context.Context, render resource.Renderer) (resource.Task, error) {
-	timeout, err := render.Render("inactivity_timeout", p.InactivityTimeout)
-	if err != nil {
-		return nil, err
-	}
-
 	dockerClient, err := docker.NewDockerClient()
 	if err != nil {
 		return nil, err
 	}
 
-	if timeout != "" {
-		duration, err := time.ParseDuration(timeout)
-		if err != nil {
-			return nil, err
-		}
-		dockerClient.PullInactivityTimeout = duration
-	}
+	dockerClient.PullInactivityTimeout = p.InactivityTimeout
 
 	image := &Image{
 		Name: p.Name,

--- a/resource/docker/image/preparer.go
+++ b/resource/docker/image/preparer.go
@@ -35,10 +35,7 @@ type Preparer struct {
 	Tag string `hcl:"tag"`
 
 	// the amount of time to wait after a period of inactivity. The timeout is
-	// reset each time new data arrives. The format is Go's duration string. A
-	// duration string is a possibly signed sequence of decimal numbers, each with
-	// optional fraction and a unit suffix, such as "300ms", "-1.5h" or "2h45m".
-	// Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+	// reset each time new data arrives.
 	InactivityTimeout time.Duration `hcl:"inactivity_timeout"`
 }
 

--- a/resource/docker/image/preparer_test.go
+++ b/resource/docker/image/preparer_test.go
@@ -17,20 +17,12 @@ package image_test
 import (
 	"testing"
 
-	"github.com/asteris-llc/converge/helpers/fakerenderer"
 	"github.com/asteris-llc/converge/resource"
 	"github.com/asteris-llc/converge/resource/docker/image"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 )
 
 func TestPreparerInterface(t *testing.T) {
 	t.Parallel()
 	assert.Implements(t, (*resource.Resource)(nil), new(image.Preparer))
-}
-
-func TestPreparerInvalidTimeout(t *testing.T) {
-	p := &image.Preparer{InactivityTimeout: "invalid"}
-	_, err := p.Prepare(context.Background(), fakerenderer.New())
-	assert.Error(t, err)
 }

--- a/resource/preparer.go
+++ b/resource/preparer.go
@@ -355,7 +355,8 @@ func (p *Preparer) convertDuration(typ reflect.Type, r Renderer, name string, va
 		if err != nil {
 			return reflect.Zero(typ), errors.Wrapf(err, "could not convert %v to duration", val)
 		}
-		dur := time.Duration(num.Int())
+
+		dur := time.Duration(num.Int() * 1E9)
 		return reflect.ValueOf(dur), nil
 
 	case reflect.String:

--- a/resource/preparer.go
+++ b/resource/preparer.go
@@ -19,6 +19,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/arbovm/levenshtein"
@@ -26,6 +27,8 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
+
+var durationType = reflect.TypeOf(time.Duration(0))
 
 // Preparer wraps and implements resource.Resource in order to deserialize into
 // regular Preparers
@@ -280,35 +283,41 @@ func (p *Preparer) validateValidValues(field reflect.StructField, r Renderer, ba
 
 // convertValue converts and returns the value of an individual element
 func (p *Preparer) convertValue(typ reflect.Type, r Renderer, name string, val interface{}, base int) (out reflect.Value, err error) {
-	switch typ.Kind() {
-	case reflect.Bool:
-		out, err = p.convertBool(r, name, val)
 
-	case reflect.String:
-		out, err = p.convertString(r, name, val)
-
-	case reflect.Interface:
-		out, err = p.convertInterface(typ, r, name, val, base)
-
-	case reflect.Map:
-		out, err = p.convertMap(typ, r, name, val, base)
-
-	case reflect.Slice:
-		out, err = p.convertSlice(typ, r, name, val, base)
-
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Float32, reflect.Float64:
-		out, err = p.convertNumber(typ, r, name, val, base)
-
-	case reflect.Ptr:
-		out, err = p.convertPointer(typ, r, name, val, base)
-
+	switch typ {
+	case durationType:
+		out, err = p.convertDuration(typ, r, name, val, base)
 	default:
-		logrus.WithFields(logrus.Fields{
-			"field": name,
-			"type":  typ.Kind(),
-		}).Warn("could not render field type, using zero value")
+		switch typ.Kind() {
+		case reflect.Bool:
+			out, err = p.convertBool(r, name, val)
 
-		out = reflect.Zero(typ)
+		case reflect.String:
+			out, err = p.convertString(r, name, val)
+
+		case reflect.Interface:
+			out, err = p.convertInterface(typ, r, name, val, base)
+
+		case reflect.Map:
+			out, err = p.convertMap(typ, r, name, val, base)
+
+		case reflect.Slice:
+			out, err = p.convertSlice(typ, r, name, val, base)
+
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Float32, reflect.Float64:
+			out, err = p.convertNumber(typ, r, name, val, base)
+
+		case reflect.Ptr:
+			out, err = p.convertPointer(typ, r, name, val, base)
+
+		default:
+			logrus.WithFields(logrus.Fields{
+				"field": name,
+				"type":  typ.Kind(),
+			}).Warn("could not render field type, using zero value")
+
+			out = reflect.Zero(typ)
+		}
 	}
 
 	if err != nil {
@@ -332,6 +341,33 @@ func (p *Preparer) realias(val reflect.Value, typ reflect.Type) (reflect.Value, 
 	}
 
 	return val, nil
+}
+
+// convertDuration converts a time.Duration
+func (p *Preparer) convertDuration(typ reflect.Type, r Renderer, name string, val interface{}, base int) (reflect.Value, error) {
+	if val == nil {
+		return reflect.Zero(typ), nil
+	}
+
+	switch reflect.ValueOf(val).Kind() {
+	case reflect.Int:
+		num, err := p.convertNumber(typ, r, name, val, base)
+		if err != nil {
+			return reflect.Zero(typ), errors.Wrapf(err, "could not convert %v to duration", val)
+		}
+		dur := time.Duration(num.Int())
+		return reflect.ValueOf(dur), nil
+
+	case reflect.String:
+		dur, err := time.ParseDuration(val.(string))
+		if err != nil {
+			return reflect.Zero(typ), errors.Wrapf(err, "could not convert %s to duration", val)
+		}
+		return reflect.ValueOf(dur), nil
+
+	default:
+		return reflect.Zero(typ), fmt.Errorf("cannot handle duration conversion of %v", reflect.ValueOf(val).Kind())
+	}
 }
 
 // convertBool converts a value to bool using the following rules:

--- a/resource/preparer_test.go
+++ b/resource/preparer_test.go
@@ -101,7 +101,7 @@ func TestPreparerPrepare(t *testing.T) {
 
 		t.Run("int64", func(t *testing.T) {
 			target := newWithField(t, "duration", 1)
-			assert.Equal(t, time.Duration(1*time.Second), target.Duration)
+			assert.Equal(t, 1*time.Second, target.Duration)
 		})
 
 		t.Run("string", func(t *testing.T) {

--- a/resource/preparer_test.go
+++ b/resource/preparer_test.go
@@ -119,7 +119,7 @@ func TestPreparerPrepare(t *testing.T) {
 					Destination: new(testPreparerTarget),
 				}
 
-				_, err := prep.Prepare(fakerenderer.New())
+				_, err := prep.Prepare(context.Background(), fakerenderer.New())
 				assert.EqualError(t, err, fmt.Sprintf("could not convert %s to duration: time: missing unit in duration %s", val, val))
 			})
 
@@ -130,7 +130,7 @@ func TestPreparerPrepare(t *testing.T) {
 					Destination: new(testPreparerTarget),
 				}
 
-				_, err := prep.Prepare(fakerenderer.New())
+				_, err := prep.Prepare(context.Background(), fakerenderer.New())
 				assert.EqualError(t, err, fmt.Sprintf("cannot handle duration conversion of %v", reflect.ValueOf(val).Kind()))
 			})
 		})

--- a/resource/preparer_test.go
+++ b/resource/preparer_test.go
@@ -101,7 +101,7 @@ func TestPreparerPrepare(t *testing.T) {
 
 		t.Run("int64", func(t *testing.T) {
 			target := newWithField(t, "duration", 1)
-			assert.Equal(t, time.Duration(1), target.Duration)
+			assert.Equal(t, time.Duration(1*time.Second), target.Duration)
 		})
 
 		t.Run("string", func(t *testing.T) {

--- a/resource/preparer_test.go
+++ b/resource/preparer_test.go
@@ -16,7 +16,9 @@ package resource_test
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
+	"time"
 
 	"github.com/asteris-llc/converge/helpers/fakerenderer"
 	"github.com/asteris-llc/converge/helpers/logging"
@@ -87,6 +89,50 @@ func TestPreparerPrepare(t *testing.T) {
 			value := map[interface{}]bool{1: true}
 			target := newWithField(t, "boolmapvalue", value)
 			assert.Equal(t, value, target.BoolMapValue)
+		})
+	})
+
+	// test time.Duration with both int64 and string
+	t.Run("duration", func(t *testing.T) {
+		t.Run("nil", func(t *testing.T) {
+			target := newWithField(t, "duration", nil)
+			assert.Equal(t, time.Duration(0), target.Duration)
+		})
+
+		t.Run("int64", func(t *testing.T) {
+			target := newWithField(t, "duration", 1)
+			assert.Equal(t, time.Duration(1), target.Duration)
+		})
+
+		t.Run("string", func(t *testing.T) {
+			duration, err := time.ParseDuration("1h")
+			require.NoError(t, err)
+			target := newWithField(t, "duration", "1h")
+			assert.Equal(t, duration, target.Duration)
+		})
+
+		t.Run("invalid", func(t *testing.T) {
+			t.Run("string", func(t *testing.T) {
+				val := "1"
+				prep := &resource.Preparer{
+					Source:      map[string]interface{}{"duration": val},
+					Destination: new(testPreparerTarget),
+				}
+
+				_, err := prep.Prepare(fakerenderer.New())
+				assert.EqualError(t, err, fmt.Sprintf("could not convert %s to duration: time: missing unit in duration %s", val, val))
+			})
+
+			t.Run("unknown", func(t *testing.T) {
+				val := 3.2
+				prep := &resource.Preparer{
+					Source:      map[string]interface{}{"duration": val},
+					Destination: new(testPreparerTarget),
+				}
+
+				_, err := prep.Prepare(fakerenderer.New())
+				assert.EqualError(t, err, fmt.Sprintf("cannot handle duration conversion of %v", reflect.ValueOf(val).Kind()))
+			})
 		})
 	})
 
@@ -267,6 +313,8 @@ type testPreparerTarget struct {
 	Strings        []string               `hcl:"strings"`
 	StringMapKey   map[string]interface{} `hcl:"stringmapkey"`
 	StringMapValue map[interface{}]string `hcl:"stringmapvalue"`
+
+	Duration time.Duration `hcl:"duration"`
 
 	Bool         bool                 `hcl:"bool"`
 	Bools        []bool               `hcl:"bools"`

--- a/resource/shell/preparer.go
+++ b/resource/shell/preparer.go
@@ -65,7 +65,7 @@ type Preparer struct {
 	Apply string `hcl:"apply"`
 
 	// the amount of time the command will wait before halting forcefully.
-	Timeout time.Duration `hcl:"timeout"`
+	Timeout *time.Duration `hcl:"timeout"`
 
 	// the working directory this command should be run in
 	Dir string `hcl:"dir"`
@@ -88,7 +88,7 @@ func (p *Preparer) Prepare(ctx context.Context, render resource.Renderer) (resou
 		Flags:       p.ExecFlags,
 		Dir:         p.Dir,
 		Env:         env,
-		Timeout:     &p.Timeout,
+		Timeout:     p.Timeout,
 	}
 
 	shell := &Shell{

--- a/resource/shell/preparer.go
+++ b/resource/shell/preparer.go
@@ -64,11 +64,7 @@ type Preparer struct {
 	// failure.)
 	Apply string `hcl:"apply"`
 
-	// the amount of time the command will wait before halting forcefully. The
-	// format is Go's duration string. A duration string is a possibly signed
-	// sequence of decimal numbers, each with optional fraction and a unit
-	// suffix, such as "300ms", "-1.5h" or "2h45m". Valid time units are "ns",
-	// "us" (or "µs"), "ms", "s", "m", "h".
+	// the amount of time the command will wait before halting forcefully.
 	Timeout time.Duration `hcl:"timeout"`
 
 	// the working directory this command should be run in

--- a/resource/shell/preparer.go
+++ b/resource/shell/preparer.go
@@ -69,7 +69,7 @@ type Preparer struct {
 	// sequence of decimal numbers, each with optional fraction and a unit
 	// suffix, such as "300ms", "-1.5h" or "2h45m". Valid time units are "ns",
 	// "us" (or "µs"), "ms", "s", "m", "h".
-	Timeout string `hcl:"timeout" doc_type:"duration string"`
+	Timeout time.Duration `hcl:"timeout"`
 
 	// the working directory this command should be run in
 	Dir string `hcl:"dir"`
@@ -92,10 +92,7 @@ func (p *Preparer) Prepare(ctx context.Context, render resource.Renderer) (resou
 		Flags:       p.ExecFlags,
 		Dir:         p.Dir,
 		Env:         env,
-	}
-
-	if duration, err := time.ParseDuration(p.Timeout); err == nil {
-		generator.Timeout = &duration
+		Timeout:     &p.Timeout,
 	}
 
 	shell := &Shell{

--- a/resource/shell/query/preparer.go
+++ b/resource/shell/query/preparer.go
@@ -30,7 +30,7 @@ type Preparer struct {
 	Query       string            `hcl:"query"`
 	CheckFlags  []string          `hcl:"check_flags"`
 	ExecFlags   []string          `hcl:"exec_flags"`
-	Timeout     time.Duration     `hcl:"timeout"`
+	Timeout     *time.Duration    `hcl:"timeout"`
 	Dir         string            `hcl:"dir"`
 	Env         map[string]string `hcl:"env"`
 }

--- a/resource/shell/query/preparer.go
+++ b/resource/shell/query/preparer.go
@@ -16,6 +16,7 @@ package query
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/asteris-llc/converge/load/registry"
 	"github.com/asteris-llc/converge/resource"
@@ -29,7 +30,7 @@ type Preparer struct {
 	Query       string            `hcl:"query"`
 	CheckFlags  []string          `hcl:"check_flags"`
 	ExecFlags   []string          `hcl:"exec_flags"`
-	Timeout     string            `hcl:"timeout" doc_type:"duration string"`
+	Timeout     time.Duration     `hcl:"timeout"`
 	Dir         string            `hcl:"dir"`
 	Env         map[string]string `hcl:"env"`
 }

--- a/resource/wait/port/preparer.go
+++ b/resource/wait/port/preparer.go
@@ -16,6 +16,7 @@ package port
 
 import (
 	"errors"
+	"time"
 
 	"github.com/asteris-llc/converge/load/registry"
 	"github.com/asteris-llc/converge/resource"
@@ -37,7 +38,7 @@ type Preparer struct {
 	// each with optional fraction and a unit suffix, such as "300ms", "-1.5h" or
 	// "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h". If
 	// the interval is not specified, it will default to 5 seconds.
-	Interval string `hcl:"interval" doc_type:"duration string"`
+	Interval *time.Duration `hcl:"interval"`
 
 	// the amount of time to wait before running the first check and after a
 	// successful check. The format is Go's duration string. A duration string is
@@ -45,11 +46,11 @@ type Preparer struct {
 	// and a unit suffix, such as "300ms", "-1.5h" or "2h45m". Valid time units
 	// are "ns", "us" (or "µs"), "ms", "s", "m", "h". If no grace period is
 	// specified, no grace period will be taken into account.
-	GracePeriod string `hcl:"grace_period" doc_type:"duration string"`
+	GracePeriod *time.Duration `hcl:"grace_period"`
 
 	// the maximum number of attempts before the wait fails. If the maximum number
 	// of retries is not set, it will default to 5.
-	MaxRetry int `hcl:"max_retry"`
+	MaxRetry *int `hcl:"max_retry"`
 }
 
 // Prepare creates a new wait.port type

--- a/resource/wait/port/preparer.go
+++ b/resource/wait/port/preparer.go
@@ -33,19 +33,13 @@ type Preparer struct {
 	// the TCP port to attempt to connect to.
 	Port int `hcl:"port" required:"true"`
 
-	// the amount of time to wait in between checks. The format is Go's duration
-	// string. A duration string is a possibly signed sequence of decimal numbers,
-	// each with optional fraction and a unit suffix, such as "300ms", "-1.5h" or
-	// "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h". If
-	// the interval is not specified, it will default to 5 seconds.
+	// the amount of time to wait in between checks. If the interval is not
+	// specified, it will default to 5 seconds.
 	Interval *time.Duration `hcl:"interval"`
 
 	// the amount of time to wait before running the first check and after a
-	// successful check. The format is Go's duration string. A duration string is
-	// a possibly signed sequence of decimal numbers, each with optional fraction
-	// and a unit suffix, such as "300ms", "-1.5h" or "2h45m". Valid time units
-	// are "ns", "us" (or "µs"), "ms", "s", "m", "h". If no grace period is
-	// specified, no grace period will be taken into account.
+	// successful check. If no grace period is specified, no grace period will be
+	// taken into account.
 	GracePeriod *time.Duration `hcl:"grace_period"`
 
 	// the maximum number of attempts before the wait fails. If the maximum number

--- a/resource/wait/preparer.go
+++ b/resource/wait/preparer.go
@@ -43,7 +43,7 @@ type Preparer struct {
 	ExecFlags []string `hcl:"exec_flags"`
 
 	// the amount of time the command will wait before halting forcefully.
-	Timeout time.Duration `hcl:"timeout"`
+	Timeout *time.Duration `hcl:"timeout"`
 
 	// the working directory this command should be run in.
 	Dir string `hcl:"dir"`

--- a/resource/wait/preparer.go
+++ b/resource/wait/preparer.go
@@ -17,6 +17,7 @@ package wait
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/asteris-llc/converge/load/registry"
 	"github.com/asteris-llc/converge/resource"
@@ -46,7 +47,7 @@ type Preparer struct {
 	// sequence of decimal numbers, each with optional fraction and a unit
 	// suffix, such as "300ms", "-1.5h" or "2h45m". Valid time units are "ns",
 	// "us" (or "µs"), "ms", "s", "m", "h".
-	Timeout string `hcl:"timeout" doc_type:"duration string"`
+	Timeout time.Duration `hcl:"timeout"`
 
 	// the working directory this command should be run in.
 	Dir string `hcl:"dir"`

--- a/resource/wait/preparer.go
+++ b/resource/wait/preparer.go
@@ -60,7 +60,7 @@ type Preparer struct {
 	// each with optional fraction and a unit suffix, such as "300ms", "-1.5h" or
 	// "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h". If
 	// the interval is not specified, it will default to 5 seconds.
-	Interval string `hcl:"interval" doc_type:"duration string"`
+	Interval *time.Duration `hcl:"interval"`
 
 	// the amount of time to wait before running the first check and after a
 	// successful check. The format is Go's duration string. A duration string is
@@ -68,11 +68,11 @@ type Preparer struct {
 	// and a unit suffix, such as "300ms", "-1.5h" or "2h45m". Valid time units
 	// are "ns", "us" (or "µs"), "ms", "s", "m", "h". If no grace period is
 	// specified, no grace period will be taken into account.
-	GracePeriod string `hcl:"grace_period" doc_type:"duration string"`
+	GracePeriod *time.Duration `hcl:"grace_period"`
 
 	// the maximum number of attempts before the wait fails. If the maximum number
 	// of retries is not set, it will default to 5.
-	MaxRetry int `hcl:"max_retry"`
+	MaxRetry *int `hcl:"max_retry"`
 }
 
 // Prepare creates a new wait type

--- a/resource/wait/preparer.go
+++ b/resource/wait/preparer.go
@@ -42,11 +42,7 @@ type Preparer struct {
 	// flags to pass to the interpreter at execution time.
 	ExecFlags []string `hcl:"exec_flags"`
 
-	// the amount of time the command will wait before halting forcefully. The
-	// format is Go's duration string. A duration string is a possibly signed
-	// sequence of decimal numbers, each with optional fraction and a unit
-	// suffix, such as "300ms", "-1.5h" or "2h45m". Valid time units are "ns",
-	// "us" (or "µs"), "ms", "s", "m", "h".
+	// the amount of time the command will wait before halting forcefully.
 	Timeout time.Duration `hcl:"timeout"`
 
 	// the working directory this command should be run in.
@@ -55,19 +51,13 @@ type Preparer struct {
 	// any environment variables that should be passed to the command.
 	Env map[string]string `hcl:"env"`
 
-	// the amount of time to wait in between checks. The format is Go's duration
-	// string. A duration string is a possibly signed sequence of decimal numbers,
-	// each with optional fraction and a unit suffix, such as "300ms", "-1.5h" or
-	// "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h". If
-	// the interval is not specified, it will default to 5 seconds.
+	// the amount of time to wait in between checks. If the interval is not
+	// specified, it will default to 5 seconds.
 	Interval *time.Duration `hcl:"interval"`
 
 	// the amount of time to wait before running the first check and after a
-	// successful check. The format is Go's duration string. A duration string is
-	// a possibly signed sequence of decimal numbers, each with optional fraction
-	// and a unit suffix, such as "300ms", "-1.5h" or "2h45m". Valid time units
-	// are "ns", "us" (or "µs"), "ms", "s", "m", "h". If no grace period is
-	// specified, no grace period will be taken into account.
+	// successful check. If no grace period is specified, no grace period will be
+	// taken into account.
 	GracePeriod *time.Duration `hcl:"grace_period"`
 
 	// the maximum number of attempts before the wait fails. If the maximum number

--- a/resource/wait/retrier.go
+++ b/resource/wait/retrier.go
@@ -18,7 +18,7 @@ import "time"
 
 const (
 	// DefaultInterval is the default amount of time to wait in between checks
-	DefaultInterval = time.Duration(5 * time.Second)
+	DefaultInterval = 5 * time.Second
 
 	// DefaultGracePeriod is the amount of time to wait before running the first
 	// check and after a successful check

--- a/resource/wait/retrier_test.go
+++ b/resource/wait/retrier_test.go
@@ -28,8 +28,8 @@ import (
 var (
 	nilDur   *time.Duration
 	zeroDur  time.Duration
-	threeSec time.Duration
-	fiveSec  time.Duration
+	threeDur time.Duration
+	fiveDur  time.Duration
 	nilInt   *int
 	retry    int
 	err      error
@@ -38,12 +38,12 @@ var (
 func init() {
 	zeroDur = time.Duration(0)
 
-	threeSec, err = time.ParseDuration("3s")
+	threeDur, err = time.ParseDuration("3s")
 	if err != nil {
 		panic(err)
 	}
 
-	fiveSec, err = time.ParseDuration("5s")
+	fiveDur, err = time.ParseDuration("5s")
 	if err != nil {
 		panic(err)
 	}
@@ -128,32 +128,32 @@ func TestPrepareRetrier(t *testing.T) {
 	t.Parallel()
 
 	t.Run("sets max retries", func(t *testing.T) {
-		r := wait.PrepareRetrier(&threeSec, &fiveSec, &retry)
+		r := wait.PrepareRetrier(&threeDur, &fiveDur, &retry)
 		assert.Equal(t, 10, r.MaxRetry)
 	})
 
 	t.Run("default max retries", func(t *testing.T) {
-		r := wait.PrepareRetrier(&threeSec, &fiveSec, nilInt)
+		r := wait.PrepareRetrier(&threeDur, &fiveDur, nilInt)
 		assert.Equal(t, wait.DefaultRetries, r.MaxRetry)
 	})
 
 	t.Run("sets interval", func(t *testing.T) {
-		r := wait.PrepareRetrier(&threeSec, &zeroDur, &retry)
+		r := wait.PrepareRetrier(&threeDur, &zeroDur, &retry)
 		assert.Equal(t, 3*time.Second, r.Interval)
 	})
 
 	t.Run("default interval", func(t *testing.T) {
-		r := wait.PrepareRetrier(nilDur, &fiveSec, &retry)
+		r := wait.PrepareRetrier(nilDur, &fiveDur, &retry)
 		assert.Equal(t, wait.DefaultInterval, r.Interval)
 	})
 
 	t.Run("sets grace period", func(t *testing.T) {
-		r := wait.PrepareRetrier(&zeroDur, &threeSec, &retry)
+		r := wait.PrepareRetrier(&zeroDur, &threeDur, &retry)
 		assert.Equal(t, 3*time.Second, r.GracePeriod)
 	})
 
 	t.Run("default grace period", func(t *testing.T) {
-		r := wait.PrepareRetrier(&fiveSec, nilDur, &retry)
+		r := wait.PrepareRetrier(&fiveDur, nilDur, &retry)
 		assert.Equal(t, wait.DefaultGracePeriod, r.GracePeriod)
 	})
 }


### PR DESCRIPTION
- Add time.Duration to resource/preparer, giving the ability to provide a duration as a number in nanoseconds or as a duration string.
- Updated the preparer for docker image, shell, and wait resources
- Added handling to documentation generation for time.Duration
- Moved duplicate comments regarding duration strings (from each of the preparers for docker image, shell, and wait resources) to be handled by docs generation