### PR TITLE
Feature/nonempty tag

### DIFF
--- a/docs/content/resources/docker.container.md
+++ b/docs/content/resources/docker.container.md
@@ -1,7 +1,7 @@
 ---
 title: "docker.container"
 slug: "docker-container"
-date: "2016-11-09T14:19:17-06:00"
+date: "2016-11-14T11:12:02-06:00"
 menu:
   main:
     parent: resources

--- a/docs/content/resources/docker.image.md
+++ b/docs/content/resources/docker.image.md
@@ -1,7 +1,7 @@
 ---
 title: "docker.image"
 slug: "docker-image"
-date: "2016-11-09T14:19:17-06:00"
+date: "2016-11-14T11:12:02-06:00"
 menu:
   main:
     parent: resources
@@ -26,13 +26,13 @@ docker.image "busybox" {
 
 ## Parameters
 
-- `name` (string)
+- `name` (required string)
 
   name of the image to pull
 
 - `tag` (string)
 
-  tag of the image to pull
+  tag of the image to pull. default: latest
 
 - `inactivity_timeout` (duration)
 

--- a/docs/content/resources/docker.network.md
+++ b/docs/content/resources/docker.network.md
@@ -1,7 +1,7 @@
 ---
 title: "docker.network"
 slug: "docker-network"
-date: "2016-11-09T14:19:17-06:00"
+date: "2016-11-14T11:12:02-06:00"
 menu:
   main:
     parent: resources

--- a/docs/content/resources/docker.volume.md
+++ b/docs/content/resources/docker.volume.md
@@ -1,7 +1,7 @@
 ---
 title: "docker.volume"
 slug: "docker-volume"
-date: "2016-11-09T14:19:17-06:00"
+date: "2016-11-14T11:12:02-06:00"
 menu:
   main:
     parent: resources

--- a/docs/content/resources/file.content.md
+++ b/docs/content/resources/file.content.md
@@ -1,7 +1,7 @@
 ---
 title: "file.content"
 slug: "file-content"
-date: "2016-11-09T14:19:17-06:00"
+date: "2016-11-14T11:12:02-06:00"
 menu:
   main:
     parent: resources
@@ -36,7 +36,7 @@ file.content "render" {
 
   Content is the file content. This will be rendered as a template.
 
-- `destination` (string)
+- `destination` (required string)
 
   Destination is the location on disk where the content will be rendered.
 

--- a/docs/content/resources/file.directory.md
+++ b/docs/content/resources/file.directory.md
@@ -1,7 +1,7 @@
 ---
 title: "file.directory"
 slug: "file-directory"
-date: "2016-11-09T14:19:17-06:00"
+date: "2016-11-14T11:12:02-06:00"
 menu:
   main:
     parent: resources
@@ -30,7 +30,7 @@ file.directory "deeper" {
 
 ## Parameters
 
-- `destination` (string)
+- `destination` (required string)
 
   the location on disk to make the directory
 

--- a/docs/content/resources/file.mode.md
+++ b/docs/content/resources/file.mode.md
@@ -1,7 +1,7 @@
 ---
 title: "file.mode"
 slug: "file-mode"
-date: "2016-11-09T14:19:17-06:00"
+date: "2016-11-14T11:12:02-06:00"
 menu:
   main:
     parent: resources

--- a/docs/content/resources/filesystem.md
+++ b/docs/content/resources/filesystem.md
@@ -1,7 +1,7 @@
 ---
 title: "filesystem"
 slug: "filesystem"
-date: "2016-11-14T11:12:02-06:00"
+date: "2016-11-14T11:47:10-06:00"
 menu:
   main:
     parent: resources

--- a/docs/content/resources/filesystem.md
+++ b/docs/content/resources/filesystem.md
@@ -1,0 +1,75 @@
+---
+title: "filesystem"
+slug: "filesystem"
+date: "2016-11-14T11:12:02-06:00"
+menu:
+  main:
+    parent: resources
+---
+
+
+Filesystem do formatting and mounting for LVM volumes
+(also capable to format usual block devices as well)
+
+
+## Example
+
+```hcl
+param "device" {
+  default = "/dev/loop0"
+}
+
+lvm.volumegroup "vg-test" {
+  name    = "test"
+  devices = ["{{ param `device` }}"]
+}
+
+lvm.logicalvolume "lv-test" {
+  group   = "test"
+  name    = "test"
+  size    = "1G"
+  depends = ["lvm.volumegroup.vg-test"]
+}
+
+filesystem "mnt-me" {
+  device  = "/dev/mapper/test-test"
+  mount   = "/mnt"
+  fstype  = "ext3"
+  depends = ["lvm.logicalvolume.lv-test"]
+}
+
+```
+
+
+## Parameters
+
+- `device` (required string)
+
+  Device path to be mount
+Examples: `/dev/sda1`, `/dev/mapper/vg0-data`
+
+- `mount` (required string)
+
+  Mountpoint where device will be mounted
+(should be an existing directory)
+Example: /mnt/data
+
+- `fstype` (required string)
+
+  Fstype is filesystem type
+(actually any linux filesystem, except `ZFS`)
+Example:  `ext4`, `xfs`
+
+- `requiredBy` (list of strings)
+
+  RequiredBy is a list of dependencies, to pass to systemd .mount unit
+
+- `wantedBy` (list of strings)
+
+  WantedBy is a list of dependencies, to pass to systemd .mount unit
+
+- `before` (list of strings)
+
+  Before is a list of dependencies, to pass to systemd .mount unit
+
+

--- a/docs/content/resources/lvm.logicalvolume.md
+++ b/docs/content/resources/lvm.logicalvolume.md
@@ -1,0 +1,63 @@
+---
+title: "lvm.logicalvolume"
+slug: "lvm-logicalvolume"
+date: "2016-11-14T11:12:02-06:00"
+menu:
+  main:
+    parent: resources
+---
+
+
+Logical volume creation
+
+
+## Example
+
+```hcl
+param "device" {
+  default = "/dev/loop0"
+}
+
+lvm.volumegroup "vg-test" {
+  name    = "test"
+  devices = ["{{ param `device` }}"]
+}
+
+lvm.logicalvolume "lv-test" {
+  group   = "test"
+  name    = "test"
+  size    = "1G"
+  depends = ["lvm.volumegroup.vg-test"]
+}
+
+filesystem "mnt-me" {
+  device  = "/dev/mapper/test-test"
+  mount   = "/mnt"
+  fstype  = "ext3"
+  depends = ["lvm.logicalvolume.lv-test"]
+}
+
+```
+
+
+## Parameters
+
+- `group` (required string)
+
+  Group where volume will be created
+
+- `name` (required string)
+
+  Name of volume, which will be created
+
+- `size` (required string)
+
+  Size of volume. Can be relative or absolute.
+Relative size set in forms like `100%FREE`
+(words after percent sign can be `FREE`, `VG`, `PV`)
+Absolute size specified with suffix `BbKkMmGgTtPp`, upper case
+suffix mean S.I. sizes (power of 10), lower case mean powers of 1024.
+Also special suffixes `Ss`, which mean sectors.
+Refer to LVM manpages for details.
+
+

--- a/docs/content/resources/lvm.logicalvolume.md
+++ b/docs/content/resources/lvm.logicalvolume.md
@@ -1,7 +1,7 @@
 ---
 title: "lvm.logicalvolume"
 slug: "lvm-logicalvolume"
-date: "2016-11-14T11:12:02-06:00"
+date: "2016-11-14T11:47:10-06:00"
 menu:
   main:
     parent: resources

--- a/docs/content/resources/lvm.volumegroup.md
+++ b/docs/content/resources/lvm.volumegroup.md
@@ -1,0 +1,64 @@
+---
+title: "lvm.volumegroup"
+slug: "lvm-volumegroup"
+date: "2016-11-14T11:12:02-06:00"
+menu:
+  main:
+    parent: resources
+---
+
+
+Volume group is responsible for creation LVM Volume Groups
+from given block devices.
+
+
+## Example
+
+```hcl
+param "device" {
+  default = "/dev/loop0"
+}
+
+lvm.volumegroup "vg-test" {
+  name    = "test"
+  devices = ["{{ param `device` }}"]
+}
+
+lvm.logicalvolume "lv-test" {
+  group   = "test"
+  name    = "test"
+  size    = "1G"
+  depends = ["lvm.volumegroup.vg-test"]
+}
+
+filesystem "mnt-me" {
+  device  = "/dev/mapper/test-test"
+  mount   = "/mnt"
+  fstype  = "ext3"
+  depends = ["lvm.logicalvolume.lv-test"]
+}
+
+```
+
+
+## Parameters
+
+- `name` (required string)
+
+  Name of created volume group
+
+- `devices` (list of strings)
+
+  Devices is list of entities to include into volume group
+
+- `remove` (bool)
+
+  Remove is enable removal devices omitted from `Devices` list from
+from volume group
+
+- `forceRemove` (bool)
+
+  ForceRemove control destruction of volumes after removing
+from volume group
+
+

--- a/docs/content/resources/lvm.volumegroup.md
+++ b/docs/content/resources/lvm.volumegroup.md
@@ -1,7 +1,7 @@
 ---
 title: "lvm.volumegroup"
 slug: "lvm-volumegroup"
-date: "2016-11-14T11:12:02-06:00"
+date: "2016-11-14T11:47:10-06:00"
 menu:
   main:
     parent: resources

--- a/docs/content/resources/module.md
+++ b/docs/content/resources/module.md
@@ -1,7 +1,7 @@
 ---
 title: "module"
 slug: "module"
-date: "2016-11-09T14:19:17-06:00"
+date: "2016-11-14T11:12:02-06:00"
 menu:
   main:
     parent: resources

--- a/docs/content/resources/package.rpm.md
+++ b/docs/content/resources/package.rpm.md
@@ -1,7 +1,7 @@
 ---
 title: "package.rpm"
 slug: "package-rpm"
-date: "2016-11-09T14:19:18-06:00"
+date: "2016-11-14T11:12:02-06:00"
 menu:
   main:
     parent: resources

--- a/docs/content/resources/param.md
+++ b/docs/content/resources/param.md
@@ -1,7 +1,7 @@
 ---
 title: "param"
 slug: "param"
-date: "2016-11-09T14:19:18-06:00"
+date: "2016-11-14T11:12:03-06:00"
 menu:
   main:
     parent: resources

--- a/docs/content/resources/task.md
+++ b/docs/content/resources/task.md
@@ -1,7 +1,7 @@
 ---
 title: "task"
 slug: "task"
-date: "2016-11-09T14:19:18-06:00"
+date: "2016-11-14T11:12:03-06:00"
 menu:
   main:
     parent: resources

--- a/docs/content/resources/task.query.md
+++ b/docs/content/resources/task.query.md
@@ -1,7 +1,7 @@
 ---
 title: "task.query"
 slug: "task-query"
-date: "2016-11-09T14:19:18-06:00"
+date: "2016-11-14T11:12:03-06:00"
 menu:
   main:
     parent: resources

--- a/docs/content/resources/user.group.md
+++ b/docs/content/resources/user.group.md
@@ -1,7 +1,7 @@
 ---
 title: "user.group"
 slug: "user-group"
-date: "2016-11-09T14:19:18-06:00"
+date: "2016-11-14T11:12:03-06:00"
 menu:
   main:
     parent: resources

--- a/docs/content/resources/user.user.md
+++ b/docs/content/resources/user.user.md
@@ -1,7 +1,7 @@
 ---
 title: "user.user"
 slug: "user-user"
-date: "2016-11-09T14:19:18-06:00"
+date: "2016-11-14T11:12:03-06:00"
 menu:
   main:
     parent: resources

--- a/docs/content/resources/wait.port.md
+++ b/docs/content/resources/wait.port.md
@@ -1,7 +1,7 @@
 ---
 title: "wait.port"
 slug: "wait-port"
-date: "2016-11-09T14:19:18-06:00"
+date: "2016-11-14T11:12:03-06:00"
 menu:
   main:
     parent: resources
@@ -29,7 +29,7 @@ wait.port "8080" {
 - `host` (string)
 
   a host name or ip address. A TCP connection will be attempted at this host
-and the specified Port.
+and the specified Port. default: localhost
 
 - `port` (required int)
 

--- a/docs/content/resources/wait.query.md
+++ b/docs/content/resources/wait.query.md
@@ -1,7 +1,7 @@
 ---
 title: "wait.query"
 slug: "wait-query"
-date: "2016-11-09T14:19:18-06:00"
+date: "2016-11-14T11:12:03-06:00"
 menu:
   main:
     parent: resources

--- a/resource/docker/container/preparer_test.go
+++ b/resource/docker/container/preparer_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/asteris-llc/converge/resource"
 	"github.com/asteris-llc/converge/resource/docker/container"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
 )
 
@@ -31,29 +32,15 @@ func TestPreparerInterface(t *testing.T) {
 	assert.Implements(t, (*resource.Resource)(nil), new(container.Preparer))
 }
 
-// TestPreparerInvalidStatus tests preparer validation
-func TestPreparerInvalidStatus(t *testing.T) {
-	t.Run("status is invalid", func(t *testing.T) {
-		p := &container.Preparer{Name: "test", Image: "nginx", Status: "exited"}
-		_, err := p.Prepare(context.Background(), fakerenderer.New())
-		if assert.Error(t, err) {
-			assert.EqualError(t, err, "status must be 'running' or 'created'")
-		}
-	})
+// TestPrepare tests Prepare
+func TestPrepare(t *testing.T) {
+	t.Parallel()
 
-	t.Run("name is invalid", func(t *testing.T) {
-		p := &container.Preparer{Name: "", Image: "nginx"}
-		_, err := p.Prepare(context.Background(), fakerenderer.New())
-		if assert.Error(t, err) {
-			assert.EqualError(t, err, "name must be provided")
-		}
-	})
-
-	t.Run("image is invalid", func(t *testing.T) {
-		p := &container.Preparer{Name: "nginx", Image: ""}
-		_, err := p.Prepare(context.Background(), fakerenderer.New())
-		if assert.Error(t, err) {
-			assert.EqualError(t, err, "image must be provided")
-		}
+	t.Run("default network mode", func(t *testing.T) {
+		p := &container.Preparer{Name: "test", Image: "nginx"}
+		task, err := p.Prepare(context.Background(), fakerenderer.New())
+		require.NoError(t, err)
+		con := task.(*container.Container)
+		assert.Equal(t, container.DefaultNetworkMode, con.NetworkMode)
 	})
 }

--- a/resource/docker/image/preparer.go
+++ b/resource/docker/image/preparer.go
@@ -29,9 +29,9 @@ import (
 // already a Docker daemon running on the system.
 type Preparer struct {
 	// name of the image to pull
-	Name string `hcl:"name"`
+	Name string `hcl:"name" required:"true" nonempty:"true"`
 
-	// tag of the image to pull
+	// tag of the image to pull. default: latest
 	Tag string `hcl:"tag"`
 
 	// the amount of time to wait after a period of inactivity. The timeout is

--- a/resource/docker/network/preparer.go
+++ b/resource/docker/network/preparer.go
@@ -15,8 +15,6 @@
 package network
 
 import (
-	"errors"
-
 	"github.com/asteris-llc/converge/load/registry"
 	"github.com/asteris-llc/converge/resource"
 	"github.com/asteris-llc/converge/resource/docker"
@@ -30,7 +28,7 @@ import (
 // already a Docker daemon running on the system.
 type Preparer struct {
 	// name of the network
-	Name string `hcl:"name" required:"true"`
+	Name string `hcl:"name" required:"true" nonempty:"true"`
 
 	// network driver. default: bridge
 	Driver string `hcl:"driver"`
@@ -73,10 +71,6 @@ type Preparer struct {
 
 // Prepare a docker network
 func (p *Preparer) Prepare(ctx context.Context, render resource.Renderer) (resource.Task, error) {
-	if p.Name == "" {
-		return nil, errors.New("name must be provided")
-	}
-
 	if p.Driver == "" {
 		p.Driver = DefaultDriver
 	}

--- a/resource/docker/network/preparer_test.go
+++ b/resource/docker/network/preparer_test.go
@@ -34,14 +34,6 @@ func TestPreparerInterface(t *testing.T) {
 
 // TestPreparerPrepare tests the Prepare function
 func TestPreparerPrepare(t *testing.T) {
-	t.Run("name is required", func(t *testing.T) {
-		p := &network.Preparer{Name: ""}
-		_, err := p.Prepare(context.Background(), fakerenderer.New())
-		if assert.Error(t, err) {
-			assert.EqualError(t, err, "name must be provided")
-		}
-	})
-
 	t.Run("state defaults to present", func(t *testing.T) {
 		p := &network.Preparer{Name: "test-network"}
 		task, err := p.Prepare(context.Background(), fakerenderer.New())
@@ -58,5 +50,14 @@ func TestPreparerPrepare(t *testing.T) {
 		require.IsType(t, (*network.Network)(nil), task)
 		nw := task.(*network.Network)
 		assert.Equal(t, network.DefaultDriver, nw.Driver)
+	})
+
+	t.Run("ipamdriver defaults to default", func(t *testing.T) {
+		p := &network.Preparer{Name: "test-network"}
+		task, err := p.Prepare(context.Background(), fakerenderer.New())
+		require.NoError(t, err)
+		require.IsType(t, (*network.Network)(nil), task)
+		nw := task.(*network.Network)
+		assert.Equal(t, network.DefaultIPAMDriver, nw.IPAM.Driver)
 	})
 }

--- a/resource/docker/volume/preparer.go
+++ b/resource/docker/volume/preparer.go
@@ -27,7 +27,7 @@ import (
 // already a Docker daemon running on the system.
 type Preparer struct {
 	// name of the volume
-	Name string `hcl:"name" required:"true"`
+	Name string `hcl:"name" required:"true" nonempty:"true"`
 
 	// volume driver. default: local
 	Driver string `hcl:"driver" default:"local"`

--- a/resource/file/content/preparer.go
+++ b/resource/file/content/preparer.go
@@ -28,7 +28,7 @@ type Preparer struct {
 	Content string `hcl:"content"`
 
 	// Destination is the location on disk where the content will be rendered.
-	Destination string `hcl:"destination"`
+	Destination string `hcl:"destination" required:"true" nonempty:"true"`
 }
 
 // Prepare a new task

--- a/resource/file/directory/preparer.go
+++ b/resource/file/directory/preparer.go
@@ -25,7 +25,7 @@ import (
 // Directory makes sure a directory is present on disk
 type Preparer struct {
 	// the location on disk to make the directory
-	Destination string `hcl:"destination"`
+	Destination string `hcl:"destination" required:"true" nonempty:"true"`
 
 	// whether or not to create all parent directories on the way up
 	CreateAll bool `hcl:"create_all"`

--- a/resource/file/directory/preparer_test.go
+++ b/resource/file/directory/preparer_test.go
@@ -1,0 +1,29 @@
+// Copyright © 2016 Asteris, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package directory_test
+
+import (
+	"testing"
+
+	"github.com/asteris-llc/converge/resource"
+	"github.com/asteris-llc/converge/resource/file/directory"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPreparerInterface(t *testing.T) {
+	t.Parallel()
+
+	assert.Implements(t, (*resource.Resource)(nil), new(directory.Preparer))
+}

--- a/resource/file/directory/preparer_test.go
+++ b/resource/file/directory/preparer_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// TestPreparerInterface tests that the Preparer interface is properly
+// implemented
 func TestPreparerInterface(t *testing.T) {
 	t.Parallel()
 

--- a/resource/file/mode/preparer.go
+++ b/resource/file/mode/preparer.go
@@ -29,7 +29,7 @@ type Preparer struct {
 	// Destination specifies which file will be modified by this resource. The
 	// file must exist on the system (for example, having been created with
 	// `file.content`.)
-	Destination string `hcl:"destination" required:"true"`
+	Destination string `hcl:"destination" required:"true" nonepmty:"true"`
 
 	// Mode is the mode of the file, specified in octal.
 	Mode *uint32 `hcl:"mode" base:"8" required:"true"`

--- a/resource/group/preparer.go
+++ b/resource/group/preparer.go
@@ -31,11 +31,11 @@ type Preparer struct {
 	GID *uint32 `hcl:"gid"`
 
 	// Name is the group name.
-	Name string `hcl:"name" required:"true"`
+	Name string `hcl:"name" required:"true" nonempty:"true"`
 
 	// NewName is used when modifying a group.
 	// The group Name will be changed to NewName.
-	NewName string `hcl:"new_name"`
+	NewName string `hcl:"new_name" nonempty:"true"`
 
 	// State is whether the group should be present.
 	// The default value is present.

--- a/resource/lvm/fs/preparer.go
+++ b/resource/lvm/fs/preparer.go
@@ -30,17 +30,17 @@ import (
 type Preparer struct {
 	// Device path to be mount
 	// Examples: `/dev/sda1`, `/dev/mapper/vg0-data`
-	Device string `hcl:"device" required:"true"`
+	Device string `hcl:"device" required:"true" nonempty:"true"`
 
 	// Mountpoint where device will be mounted
 	// (should be an existing directory)
 	// Example: /mnt/data
-	Mountpoint string `hcl:"mount" required:"true"`
+	Mountpoint string `hcl:"mount" required:"true" nonempty:"true"`
 
 	// Fstype is filesystem type
 	// (actually any linux filesystem, except `ZFS`)
 	// Example:  `ext4`, `xfs`
-	Fstype string `hcl:"fstype" required:"true"`
+	Fstype string `hcl:"fstype" required:"true" nonempty:"true"`
 
 	// RequiredBy is a list of dependencies, to pass to systemd .mount unit
 	RequiredBy []string `hcl:"requiredBy"`

--- a/resource/lvm/lv/preparer.go
+++ b/resource/lvm/lv/preparer.go
@@ -26,10 +26,10 @@ import (
 // Logical volume creation
 type Preparer struct {
 	// Group where volume will be created
-	Group string `hcl:"group" required:"true"`
+	Group string `hcl:"group" required:"true" nonempty:"true"`
 
 	// Name of volume, which will be created
-	Name string `hcl:"name" required:"true"`
+	Name string `hcl:"name" required:"true" nonempty:"true"`
 
 	// Size of volume. Can be relative or absolute.
 	// Relative size set in forms like `100%FREE`
@@ -38,7 +38,7 @@ type Preparer struct {
 	// suffix mean S.I. sizes (power of 10), lower case mean powers of 1024.
 	// Also special suffixes `Ss`, which mean sectors.
 	// Refer to LVM manpages for details.
-	Size string `hcl:"size" required:"true"`
+	Size string `hcl:"size" required:"true" nonempty:"true"`
 }
 
 // Prepare a new task

--- a/resource/lvm/vg/preparer.go
+++ b/resource/lvm/vg/preparer.go
@@ -28,7 +28,7 @@ import (
 // from given block devices.
 type Preparer struct {
 	// Name of created volume group
-	Name string `hcl:"name" required:"true"`
+	Name string `hcl:"name" required:"true" nonempty:"true"`
 
 	// Devices is list of entities to include into volume group
 	Devices []string `hcl:"devices"`

--- a/resource/package/apt/preparer.go
+++ b/resource/package/apt/preparer.go
@@ -16,7 +16,6 @@ package apt
 
 import (
 	"errors"
-
 	"strings"
 
 	"github.com/asteris-llc/converge/load/registry"
@@ -32,7 +31,7 @@ import (
 // permissions to install, remove, and query packages.
 type Preparer struct {
 	// Name of the package or package group.
-	Name string `hcl:"name" required:"true" `
+	Name string `hcl:"name" required:"true" nonempty:"true"`
 
 	// State of the package. Present means the package will be installed if
 	// missing; Absent means the package will be uninstalled if present.

--- a/resource/package/apt/preparer_test.go
+++ b/resource/package/apt/preparer_test.go
@@ -64,13 +64,6 @@ func TestPreparerCreatesPackage(t *testing.T) {
 		assert.Equal(t, "present", string(asAPT.State))
 	})
 
-	t.Run("when-name-null", func(t *testing.T) {
-		p := &apt.Preparer{Name: "", State: "present"}
-		_, err := p.Prepare(context.Background(), fakerenderer.New())
-		require.Error(t, err)
-		assert.EqualError(t, err, "package name cannot be empty")
-	})
-
 	t.Run("when-name-space", func(t *testing.T) {
 		p := &apt.Preparer{Name: " ", State: "present"}
 		_, err := p.Prepare(context.Background(), fakerenderer.New())

--- a/resource/package/rpm/preparer.go
+++ b/resource/package/rpm/preparer.go
@@ -31,7 +31,7 @@ import (
 // permissions to install, remove, and query packages.
 type Preparer struct {
 	// Name of the package or package group.
-	Name string `hcl:"name" required:"true" `
+	Name string `hcl:"name" required:"true" nonempty:"true"`
 
 	// State of the package. Present means the package will be installed if
 	// missing; Absent means the package will be uninstalled if present.

--- a/resource/preparer.go
+++ b/resource/preparer.go
@@ -155,6 +155,11 @@ func (p *Preparer) getValueForField(r Renderer, field reflect.StructField) (refl
 		return reflect.Zero(field.Type), err
 	}
 
+	// validate that the param is nonempty, if a value is required
+	if err := p.validateNonempty(field, raw); err != nil {
+		return reflect.Zero(field.Type), err
+	}
+
 	// return a default type if nothing is set. No need to do any conversions or
 	// anything in this case, we're simply returning the zero value of the field.
 	if !isSet {
@@ -217,6 +222,16 @@ func (p *Preparer) getBase(field reflect.StructField) (int, error) {
 func (p *Preparer) validateRequired(field reflect.StructField, val interface{}) error {
 	if required, ok := field.Tag.Lookup("required"); ok && required == "true" && val == nil {
 		return fmt.Errorf("%q is required", p.getFieldName(field))
+	}
+
+	return nil
+}
+
+// validateNonempty detects if the value provided is an empty string, but
+// should be nonempty
+func (p *Preparer) validateNonempty(field reflect.StructField, val interface{}) error {
+	if nonempty, ok := field.Tag.Lookup("nonempty"); ok && nonempty == "true" && val == "" {
+		return fmt.Errorf("%q must be nonempty", p.getFieldName(field))
 	}
 
 	return nil

--- a/resource/shell/preparer.go
+++ b/resource/shell/preparer.go
@@ -57,12 +57,12 @@ type Preparer struct {
 	// the script to run to check if a resource needs to be changed. It should
 	// exit with exit code 0 if the resource does not need to be changed, and
 	// 1 (or above) otherwise.
-	Check string `hcl:"check"`
+	Check string `hcl:"check" nonempty:"true"`
 
 	// the script to run to apply the resource. Normal shell exit code
 	// expectations apply (that is, exit code 0 for success, 1 or above for
 	// failure.)
-	Apply string `hcl:"apply"`
+	Apply string `hcl:"apply" nonempty:"true"`
 
 	// the amount of time the command will wait before halting forcefully.
 	Timeout *time.Duration `hcl:"timeout"`

--- a/resource/shell/query/preparer.go
+++ b/resource/shell/query/preparer.go
@@ -27,7 +27,7 @@ import (
 // Preparer handles querying
 type Preparer struct {
 	Interpreter string            `hcl:"interpreter"`
-	Query       string            `hcl:"query"`
+	Query       string            `hcl:"query" nonempty:"true"`
 	CheckFlags  []string          `hcl:"check_flags"`
 	ExecFlags   []string          `hcl:"exec_flags"`
 	Timeout     *time.Duration    `hcl:"timeout"`

--- a/resource/shell/query/preparer_test.go
+++ b/resource/shell/query/preparer_test.go
@@ -22,7 +22,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_Preparer_ImplementsResourceInterface(t *testing.T) {
+// TestPreparerImplementsResourceInterface tests that the Preparer interface
+// is properly implemented
+func TestPreparerImplementsResourceInterface(t *testing.T) {
 	t.Parallel()
 	assert.Implements(t, (*resource.Resource)(nil), new(query.Preparer))
 }

--- a/resource/shell/query/preparer_test.go
+++ b/resource/shell/query/preparer_test.go
@@ -1,0 +1,28 @@
+// Copyright © 2016 Asteris, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package query_test
+
+import (
+	"testing"
+
+	"github.com/asteris-llc/converge/resource"
+	"github.com/asteris-llc/converge/resource/shell/query"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Preparer_ImplementsResourceInterface(t *testing.T) {
+	t.Parallel()
+	assert.Implements(t, (*resource.Resource)(nil), new(query.Preparer))
+}

--- a/resource/user/preparer.go
+++ b/resource/user/preparer.go
@@ -28,20 +28,20 @@ import (
 // User renders user data
 type Preparer struct {
 	// Username is the user login name.
-	Username string `hcl:"username" required:"true"`
+	Username string `hcl:"username" required:"true" nonempty:"true"`
 
 	// NewUsername is used when modifying a user.
 	// Username will be changed to NewUsername. No changes to the home directory
 	// name or location of the contents will be made. This can be done using
 	// HomeDir and MoveDir options.
-	NewUsername string `hcl:"new_username"`
+	NewUsername string `hcl:"new_username" nonempty:"true"`
 
 	// UID is the user ID.
 	UID *uint32 `hcl:"uid"`
 
 	// GroupName is the primary group for user and must already exist.
 	// Only one of GID or Groupname may be indicated.
-	GroupName string `hcl:"groupname" mutually_exclusive:"gid,groupname"`
+	GroupName string `hcl:"groupname" mutually_exclusive:"gid,groupname" nonempty:"true"`
 
 	// Gid is the primary group ID for user and must refer to an existing group.
 	// Only one of GID or Groupname may be indicated.
@@ -49,7 +49,7 @@ type Preparer struct {
 
 	// Name is the user description.
 	// This field can be indicated when adding or modifying a user.
-	Name string `hcl:"name"`
+	Name string `hcl:"name" nonempty:"true"`
 
 	// CreateHome when set to true will create the home directory for the user.
 	// The files and directories contained in the skeleton directory (which can be
@@ -60,13 +60,13 @@ type Preparer struct {
 	// directory when adding a user. If not set, the skeleton directory is defined
 	// by the SKEL variable in /etc/default/useradd or, by default, /etc/skel.
 	// SkelDir is only valid is CreatHome is specified.
-	SkelDir string `hcl:"skel_dir"`
+	SkelDir string `hcl:"skel_dir" nonempty:"true"`
 
 	// HomeDir is the name of the user's login directory. If not set, the home
 	// directory is defined by appending the value of Username to the HOME
 	// variable in /etc/default/useradd, resulting in /HOME/Username.
 	// This field can be indicated when adding or modifying a user.
-	HomeDir string `hcl:"home_dir"`
+	HomeDir string `hcl:"home_dir" nonempty:"true"`
 
 	// MoveDir is used to move the contents of HomeDir when modifying a user.
 	// HomeDir must also be indicated if MoveDir is set to true.

--- a/resource/wait/port/preparer.go
+++ b/resource/wait/port/preparer.go
@@ -27,7 +27,7 @@ import (
 // Preparer handles wait.query tasks
 type Preparer struct {
 	// a host name or ip address. A TCP connection will be attempted at this host
-	// and the specified Port.
+	// and the specified Port. default: localhost
 	Host string `hcl:"host"`
 
 	// the TCP port to attempt to connect to.

--- a/resource/wait/preparer.go
+++ b/resource/wait/preparer.go
@@ -15,7 +15,6 @@
 package wait
 
 import (
-	"errors"
 	"fmt"
 	"time"
 
@@ -33,7 +32,7 @@ type Preparer struct {
 
 	// the script to run to check if a resource is ready. exit with exit code 0 if
 	// the resource is healthy, and 1 (or above) otherwise.
-	Check string `hcl:"check" required:"true"`
+	Check string `hcl:"check" required:"true" nonempty:"true"`
 
 	// flags to pass to the `interpreter` binary to check validity. For
 	// `/bin/sh` this is `-n`.
@@ -67,10 +66,6 @@ type Preparer struct {
 
 // Prepare creates a new wait type
 func (p *Preparer) Prepare(ctx context.Context, render resource.Renderer) (resource.Task, error) {
-	if p.Check == "" {
-		return nil, errors.New("Check is required and cannot be empty")
-	}
-
 	shPrep := &shell.Preparer{
 		Interpreter: p.Interpreter,
 		Check:       p.Check,

--- a/resource/wait/preparer_test.go
+++ b/resource/wait/preparer_test.go
@@ -39,12 +39,6 @@ func TestPreparerPrepare(t *testing.T) {
 	t.Parallel()
 	defer logging.HideLogs(t)()
 
-	t.Run("invalid check", func(t *testing.T) {
-		p := &wait.Preparer{Check: ""}
-		_, err := p.Prepare(context.Background(), fakerenderer.New())
-		assert.Error(t, err)
-	})
-
 	t.Run("initializes task", func(t *testing.T) {
 		var waitTask *wait.Wait
 		p := &wait.Preparer{Check: "test"}


### PR DESCRIPTION
Add `nonempty` tag to resource/preparer. If the tag is used in a particular resource's preparer, we verify it has a value (for any interface type).

Addresses #486 and #337 