### PR TITLE
Feature/improve output

### DIFF
--- a/prettyprinters/human/human.go
+++ b/prettyprinters/human/human.go
@@ -70,7 +70,20 @@ func (p *Printer) StartPP(g *graph.Graph) (pp.Renderable, error) {
 
 // FinishPP provides summary statistics about the printed graph
 func (p *Printer) FinishPP(g *graph.Graph) (pp.Renderable, error) {
-	tmpl, err := p.template("{{if .Errors}}Errors:\n{{range .Errors}} * {{.}}\n{{end}}\n{{end}}{{if .DependencyErrors}}Failed due to failing dependency:\n{{range .DependencyErrors}} * {{.}}\n{{end}}\n{{end}}{{if gt (len .Errors) 0}}{{red \"Summary\"}}{{else}}{{green \"Summary\"}}{{end}}: {{len .Errors}} errors, {{.ChangesCount}} changes{{if .DependencyErrors}}, {{len .DependencyErrors}} dependency errors{{end}}\n")
+	tmpl, err := p.template(`{{if .Errors}}Errors:
+{{range .Errors}} * {{.}}
+{{end}}
+{{end}}
+{{- if .DependencyErrors}}Failed due to failing dependency:
+{{range .DependencyErrors}} * {{.}}
+{{end}}
+{{end}}
+{{- if gt (len .Errors) 0}}{{red "Summary"}}
+{{- else}}{{green "Summary"}}
+{{- end}}: {{len .Errors}} errors, {{.ChangesCount}} changes
+{{- if .DependencyErrors}}, {{len .DependencyErrors}} dependency errors
+{{- end}}
+`)
 	if err != nil {
 		return pp.HiddenString(), err
 	}

--- a/prettyprinters/human/human.go
+++ b/prettyprinters/human/human.go
@@ -70,14 +70,15 @@ func (p *Printer) StartPP(g *graph.Graph) (pp.Renderable, error) {
 
 // FinishPP provides summary statistics about the printed graph
 func (p *Printer) FinishPP(g *graph.Graph) (pp.Renderable, error) {
-	tmpl, err := p.template("{{if gt (len .Errors) 0}}{{red \"Summary\"}}{{else}}{{green \"Summary\"}}{{end}}: {{len .Errors}} errors, {{.ChangesCount}} changes{{if .Errors}}\n{{range .Errors}}\n * {{.}}{{end}}{{end}}\n")
+	tmpl, err := p.template("{{if .Errors}}Errors:\n{{range .Errors}} * {{.}}\n{{end}}\n{{end}}{{if .DependencyErrors}}Failed due to failing dependency:\n{{range .DependencyErrors}} * {{.}}\n{{end}}\n{{end}}{{if gt (len .Errors) 0}}{{red \"Summary\"}}{{else}}{{green \"Summary\"}}{{end}}: {{len .Errors}} errors, {{.ChangesCount}} changes{{if .DependencyErrors}}, {{len .DependencyErrors}} dependency errors{{end}}\n")
 	if err != nil {
 		return pp.HiddenString(), err
 	}
 
 	counts := struct {
-		ChangesCount int
-		Errors       []error
+		ChangesCount     int
+		Errors           []error
+		DependencyErrors []error
 	}{}
 
 	for _, id := range g.Vertices() {
@@ -91,15 +92,22 @@ func (p *Printer) FinishPP(g *graph.Graph) (pp.Renderable, error) {
 			continue
 		}
 
-		if printable.HasChanges() {
-			counts.ChangesCount++
-		}
-
 		if err = printable.Error(); err != nil {
-			counts.Errors = append(
-				counts.Errors,
-				errors.Wrap(err, id),
-			)
+			if id != "root" {
+				if strings.Contains(err.Error(), "error in dependency") {
+					counts.DependencyErrors = append(
+						counts.DependencyErrors,
+						errors.Wrap(err, id),
+					)
+				} else {
+					counts.Errors = append(
+						counts.Errors,
+						errors.Wrap(err, id),
+					)
+				}
+			}
+		} else if printable.HasChanges() && id != "root" {
+			counts.ChangesCount++
 		}
 	}
 

--- a/prettyprinters/prettyprinter.go
+++ b/prettyprinters/prettyprinter.go
@@ -16,6 +16,7 @@ package prettyprinters
 
 import (
 	"bytes"
+	"strings"
 
 	"github.com/asteris-llc/converge/graph"
 	"golang.org/x/net/context"
@@ -52,7 +53,9 @@ func (p Printer) Show(ctx context.Context, g *graph.Graph) (string, error) {
 	if npOK {
 		for _, node := range rootNodes {
 			if str, err := nodePrinter.DrawNode(g, node); err == nil {
-				write(str)
+				if !strings.Contains(str.String(), "error in dependency") {
+					write(str)
+				}
 			} else {
 				return "", err
 			}


### PR DESCRIPTION
Improve output, specifically errors/cascading errors due to an error in a dependency.

Changes:
- Do not draw nodes of dependency errors
- In the summary, list dependency errors if any
- Only sum the changes if the change does not have an associated error/dependency error

Fixes #367 
