### PR TITLE
docs: use same formatting for (re)exported fields as parameters

### DIFF
--- a/docs/content/resources/docker.container.md
+++ b/docs/content/resources/docker.container.md
@@ -1,7 +1,7 @@
 ---
 title: "docker.container"
 slug: "docker-container"
-date: "2016-12-16T11:20:34-06:00"
+date: "2016-12-19T10:12:40-06:00"
 menu:
   main:
     parent: resources
@@ -127,54 +127,71 @@ will have their own fields exported under the re-exported namespace.
 
 
 - `name` (string)
+
   the name of the container
  
 - `image` (string)
+
   the name of the image
  
 - `entrypoint` (list of strings)
+
   the entrypoint into the container
  
 - `command` (list of strings)
+
   the command to run
  
 - `workingdir` (string)
+
   the working directory
  
 - `env` (list of strings)
+
   configured environment variables for the container
  
 - `expose` (list of strings)
+
   additional ports to exposed in the container
  
 - `links` (list of strings)
+
   A list of links for the container in the form of container_name:alias
  
 - `portbindings` (list of strings)
+
   ports to bind
  
 - `dns` (list of strings)
+
   list of DNS servers the container is using
  
 - `volumes` (list of strings)
+
   volumes that have been bind-mounted
  
 - `volumesfrom` (list of strings)
+
   containers from which volumes have been mounted
  
 - `publishallports` (bool)
+
   if true, all ports have been published
  
 - `networkmode` (string)
+
   the mode of the container network
  
 - `networks` (list of strings)
+
   networks the container is connected to
  
 - `status` (string)
+
   the status of the container.
  
 - `force` (bool)
+
   Indicate whether the 'force' flag was set
   
 

--- a/docs/content/resources/docker.image.md
+++ b/docs/content/resources/docker.image.md
@@ -1,7 +1,7 @@
 ---
 title: "docker.image"
 slug: "docker-image"
-date: "2016-12-16T11:20:34-06:00"
+date: "2016-12-19T10:12:40-06:00"
 menu:
   main:
     parent: resources
@@ -60,9 +60,11 @@ will have their own fields exported under the re-exported namespace.
 
 
 - `name` (string)
+
   name of the image
  
 - `tag` (string)
+
   tag of the image
   
 

--- a/docs/content/resources/docker.network.md
+++ b/docs/content/resources/docker.network.md
@@ -1,7 +1,7 @@
 ---
 title: "docker.network"
 slug: "docker-network"
-date: "2016-12-16T11:20:34-06:00"
+date: "2016-12-19T10:12:40-06:00"
 menu:
   main:
     parent: resources
@@ -116,30 +116,39 @@ will have their own fields exported under the re-exported namespace.
 
 
 - `name` (string)
+
   name of the network
  
 - `driver` (string)
+
   network drive configured in the hcl
  
 - `labels` (map of string to string)
+
   labels set on the network
  
 - `options` (map of string to anything)
+
   driver-specific options that have been configured
  
 - `ipam` (dc.IPAMOptions)
+
   docker client IPAM options
  
 - `internal` (bool)
+
   restricted to internal networking
  
 - `ipv6` (bool)
+
   uses ipv6
  
 - `state` (State)
+
   the configured state
  
 - `force` (bool)
+
   true if 'force' was specified in the hcl
   
 

--- a/docs/content/resources/docker.volume.md
+++ b/docs/content/resources/docker.volume.md
@@ -1,7 +1,7 @@
 ---
 title: "docker.volume"
 slug: "docker-volume"
-date: "2016-12-16T11:20:34-06:00"
+date: "2016-12-19T10:12:40-06:00"
 menu:
   main:
     parent: resources
@@ -74,21 +74,27 @@ will have their own fields exported under the re-exported namespace.
 
 
 - `name` (string)
+
   volume name
  
 - `labels` (map of string to string)
+
   volume labels
  
 - `driver` (string)
+
   driver the volume is configured to use
  
 - `options` (map of string to string)
+
   driver-specific options
  
 - `state` (State)
+
   volume state
  
 - `force` (bool)
+
   reflects whether or not the force option was configured
   
 

--- a/docs/content/resources/file.content.md
+++ b/docs/content/resources/file.content.md
@@ -1,7 +1,7 @@
 ---
 title: "file.content"
 slug: "file-content"
-date: "2016-12-16T11:20:34-06:00"
+date: "2016-12-19T10:12:40-06:00"
 menu:
   main:
     parent: resources
@@ -52,9 +52,11 @@ will have their own fields exported under the re-exported namespace.
 
 
 - `content` (string)
+
   configured content of the file
  
 - `destination` (string)
+
   configured destination of the file
   
 

--- a/docs/content/resources/file.directory.md
+++ b/docs/content/resources/file.directory.md
@@ -1,7 +1,7 @@
 ---
 title: "file.directory"
 slug: "file-directory"
-date: "2016-12-16T11:20:34-06:00"
+date: "2016-12-19T10:12:41-06:00"
 menu:
   main:
     parent: resources
@@ -50,9 +50,11 @@ will have their own fields exported under the re-exported namespace.
 
 
 - `destination` (string)
+
   directory path
  
 - `createall` (bool)
+
   if true, directories will be created recursively
   
 

--- a/docs/content/resources/file.fetch.md
+++ b/docs/content/resources/file.fetch.md
@@ -1,7 +1,7 @@
 ---
 title: "file.fetch"
 slug: "file-fetch"
-date: "2016-12-16T11:20:34-06:00"
+date: "2016-12-19T10:12:41-06:00"
 menu:
   main:
     parent: resources
@@ -62,19 +62,24 @@ will have their own fields exported under the re-exported namespace.
 
 
 - `source` (string)
+
   location of the file to fetch
  
 - `destination` (string)
+
   destination for the fetched file
  
 - `hash_type` (string)
+
   hash function used to generate the checksum hash; value is available for
 lookup if set in the hcl
  
 - `hash` (string)
+
   the checksum hash; value is available for lookup if set in the hcl
  
 - `force` (bool)
+
   whether the file will be fetched if it already exists
   
 

--- a/docs/content/resources/file.mode.md
+++ b/docs/content/resources/file.mode.md
@@ -1,7 +1,7 @@
 ---
 title: "file.mode"
 slug: "file-mode"
-date: "2016-12-16T11:20:34-06:00"
+date: "2016-12-19T10:12:41-06:00"
 menu:
   main:
     parent: resources
@@ -50,9 +50,11 @@ will have their own fields exported under the re-exported namespace.
 
 
 - `destination` (string)
+
   path to the file that will be modified
  
 - `mode` (os.FileMode)
+
   the mode that the file or directory should be configured with
   
 

--- a/docs/content/resources/filesystem.md
+++ b/docs/content/resources/filesystem.md
@@ -1,7 +1,7 @@
 ---
 title: "filesystem"
 slug: "filesystem"
-date: "2016-12-16T11:20:34-06:00"
+date: "2016-12-19T10:12:41-06:00"
 menu:
   main:
     parent: resources

--- a/docs/content/resources/lvm.logicalvolume.md
+++ b/docs/content/resources/lvm.logicalvolume.md
@@ -1,7 +1,7 @@
 ---
 title: "lvm.logicalvolume"
 slug: "lvm-logicalvolume"
-date: "2016-12-16T11:20:34-06:00"
+date: "2016-12-19T10:12:41-06:00"
 menu:
   main:
     parent: resources

--- a/docs/content/resources/lvm.volumegroup.md
+++ b/docs/content/resources/lvm.volumegroup.md
@@ -1,7 +1,7 @@
 ---
 title: "lvm.volumegroup"
 slug: "lvm-volumegroup"
-date: "2016-12-16T11:20:34-06:00"
+date: "2016-12-19T10:12:41-06:00"
 menu:
   main:
     parent: resources

--- a/docs/content/resources/module.md
+++ b/docs/content/resources/module.md
@@ -1,7 +1,7 @@
 ---
 title: "module"
 slug: "module"
-date: "2016-12-16T11:20:34-06:00"
+date: "2016-12-19T10:12:41-06:00"
 menu:
   main:
     parent: resources

--- a/docs/content/resources/package.apt.md
+++ b/docs/content/resources/package.apt.md
@@ -1,7 +1,7 @@
 ---
 title: "package.apt"
 slug: "package-apt"
-date: "2016-12-16T11:20:35-06:00"
+date: "2016-12-19T10:12:41-06:00"
 menu:
   main:
     parent: resources
@@ -50,9 +50,11 @@ will have their own fields exported under the re-exported namespace.
 
 
 - `name` (string)
+
   name of the package
  
 - `state` (State)
+
   package state; one of "present" or "absent"
   
 

--- a/docs/content/resources/package.rpm.md
+++ b/docs/content/resources/package.rpm.md
@@ -1,7 +1,7 @@
 ---
 title: "package.rpm"
 slug: "package-rpm"
-date: "2016-12-16T11:20:35-06:00"
+date: "2016-12-19T10:12:41-06:00"
 menu:
   main:
     parent: resources
@@ -50,9 +50,11 @@ will have their own fields exported under the re-exported namespace.
 
 
 - `name` (string)
+
   name of the package
  
 - `state` (State)
+
   package state; one of "present" or "absent"
   
 

--- a/docs/content/resources/param.md
+++ b/docs/content/resources/param.md
@@ -1,7 +1,7 @@
 ---
 title: "param"
 slug: "param"
-date: "2016-12-16T11:20:35-06:00"
+date: "2016-12-19T10:12:41-06:00"
 menu:
   main:
     parent: resources

--- a/docs/content/resources/task.md
+++ b/docs/content/resources/task.md
@@ -1,7 +1,7 @@
 ---
 title: "task"
 slug: "task"
-date: "2016-12-16T11:20:35-06:00"
+date: "2016-12-19T10:12:41-06:00"
 menu:
   main:
     parent: resources
@@ -90,24 +90,31 @@ will have their own fields exported under the re-exported namespace.
 
 
 - `check` (string)
+
   the check statement
  
 - `apply` (string)
+
   the apply statement
  
 - `dir` (string)
+
   the working directory of the task
  
 - `env` (list of strings)
+
   environment variables configured for the task
  
 - `checkstatus` (CommandResults)
+
   the status of the check phase
  
 - `healthstatus` (resource.HealthStatus)
+
   the status of the health check
  
 - `status` re-exports fields from CommandResults
+
   the status of the task
   
 

--- a/docs/content/resources/task.query.md
+++ b/docs/content/resources/task.query.md
@@ -1,7 +1,7 @@
 ---
 title: "task.query"
 slug: "task-query"
-date: "2016-12-16T11:20:35-06:00"
+date: "2016-12-19T10:12:41-06:00"
 menu:
   main:
     parent: resources

--- a/docs/content/resources/user.group.md
+++ b/docs/content/resources/user.group.md
@@ -1,7 +1,7 @@
 ---
 title: "user.group"
 slug: "user-group"
-date: "2016-12-16T11:20:35-06:00"
+date: "2016-12-19T10:12:41-06:00"
 menu:
   main:
     parent: resources
@@ -57,15 +57,19 @@ will have their own fields exported under the re-exported namespace.
 
 
 - `gid` (string)
+
   the configured group ID
  
 - `name` (string)
+
   the configured group name
  
 - `newname` (string)
+
   the desired group name
  
 - `state` (State)
+
   the group state
   
 

--- a/docs/content/resources/user.user.md
+++ b/docs/content/resources/user.user.md
@@ -1,7 +1,7 @@
 ---
 title: "user.user"
 slug: "user-user"
-date: "2016-12-16T11:20:35-06:00"
+date: "2016-12-19T10:12:42-06:00"
 menu:
   main:
     parent: resources
@@ -105,36 +105,47 @@ will have their own fields exported under the re-exported namespace.
 
 
 - `username` (string)
+
   the configured username
  
 - `newusername` (string)
+
   the desired username
  
 - `uid` (string)
+
   the user id
  
 - `groupname` (string)
+
   the group name
  
 - `gid` (string)
+
   the group id
  
 - `name` (string)
+
   the real name of the user
  
 - `createhome` (bool)
+
   if the home directory should be created
  
 - `skeldir` (string)
+
   the path to the skeleton directory
  
 - `homedir` (string)
+
   the path to the home directory
  
 - `movedir` (bool)
+
   if the contents of the home directory should be moved
  
 - `state` (State)
+
   configured the user state
   
 

--- a/docs/content/resources/wait.port.md
+++ b/docs/content/resources/wait.port.md
@@ -1,7 +1,7 @@
 ---
 title: "wait.port"
 slug: "wait-port"
-date: "2016-12-16T11:20:35-06:00"
+date: "2016-12-19T10:12:42-06:00"
 menu:
   main:
     parent: resources
@@ -77,9 +77,11 @@ will have their own fields exported under the re-exported namespace.
 
 
 - `host` (string)
+
   the hostname
  
 - `port` (int)
+
   the TCP port
   
 

--- a/docs/content/resources/wait.query.md
+++ b/docs/content/resources/wait.query.md
@@ -1,7 +1,7 @@
 ---
 title: "wait.query"
 slug: "wait-query"
-date: "2016-12-16T11:20:35-06:00"
+date: "2016-12-19T10:12:42-06:00"
 menu:
   main:
     parent: resources

--- a/docs/extract.go
+++ b/docs/extract.go
@@ -100,9 +100,11 @@ will have their own fields exported under the re-exported namespace.
 
 {{range .GetExported}}
 - {{.ExportedAs}} ({{.Type}})
+
 {{if ne .Doc ""}}  {{.Doc}}{{end}} {{end}}
 {{- range .GetReExported}}
 - {{.ExportedAs}} re-exports fields from {{.Type}}
+
 {{if ne .Doc ""}}  {{.Doc}}{{end}} {{end}} {{end}}
 `))
 )


### PR DESCRIPTION
Add a newline after the name and type for exported and re-exported fields.
Fixes #548 