### PR TITLE
Sleep in Graph Generation Test

### DIFF
--- a/blackbox/test_graph_generation.sh
+++ b/blackbox/test_graph_generation.sh
@@ -6,7 +6,7 @@ TMP=$(mktemp -d -t converge.graphviz.XXXXXXXXXX)
 
 "$ROOT"/converge server --no-token &
 PID=$!
-sleep 1
+sleep 0.25
 
 function finish {
     rm -fr "$TMP"

--- a/blackbox/test_graph_generation.sh
+++ b/blackbox/test_graph_generation.sh
@@ -6,6 +6,7 @@ TMP=$(mktemp -d -t converge.graphviz.XXXXXXXXXX)
 
 "$ROOT"/converge server --no-token &
 PID=$!
+sleep 1
 
 function finish {
     rm -fr "$TMP"

--- a/blackbox/test_graph_generation.sh
+++ b/blackbox/test_graph_generation.sh
@@ -6,7 +6,7 @@ TMP=$(mktemp -d -t converge.graphviz.XXXXXXXXXX)
 
 "$ROOT"/converge server --no-token &
 PID=$!
-sleep 0.25
+sleep 1
 
 function finish {
     rm -fr "$TMP"


### PR DESCRIPTION
There wasn't any sleeping in the graph generation test. I'm not sure why it didn't give us problems before, but it is now. This PR adds a quarter second sleep between starting the server and using it.