### PR TITLE
update pip package to fix failing example

### DIFF
--- a/examples/docker-swarm-mode/converge/awscli.hcl
+++ b/examples/docker-swarm-mode/converge/awscli.hcl
@@ -4,7 +4,7 @@ package.rpm "epel-install" {
 }
 
 package.rpm "pip-install" {
-  name  = "python-pip"
+  name  = "python2-pip"
   state = "present"
 
   depends = ["package.rpm.epel-install"]


### PR DESCRIPTION
the docker swarm example fails due to a name change in the python-pip package.