### PR TITLE
add status method-raise level to will change when there are diffs

### DIFF
--- a/docs/content/resource-authors-guide.md
+++ b/docs/content/resource-authors-guide.md
@@ -78,6 +78,8 @@ smoothly.  Of particular note are:
    which allows you to add a message that will be displayed to the user
 1. [`AddDifference`](https://godoc.org/github.com/asteris-llc/converge/resource#Status.AddDifference)
    which inserts a difference that will be displayed to the user
+1. [`RaiseLevelForDiffs`](https://godoc.org/github.com/asteris-llc/converge/resource#Status.RaiseLevelForDiffs)
+   which raises the level to `StatusWillChange` if there are any differences
 
 `Status` has three fields: `Differences`, `Output`, and `Level`. They all have
 accurate documentation on their fields, which we will not repeat here. However,
@@ -86,7 +88,8 @@ These two fields are how you control execution of your Apply method. They follow
 these rules:
 
 1. If the level is equal to
-   [`resource.StatusWillChange`](https://godoc.org/github.com/asteris-llc/converge/resource#StatusLevel)
+   [`resource.StatusWillChange`](https://godoc.org/github.com/asteris-llc/converge/resource#StatusLevel),
+   [`resource.StatusMayChange`](https://godoc.org/github.com/asteris-llc/converge/resource#StatusLevel),
    or
    [`resource.StatusCantChange`](https://godoc.org/github.com/asteris-llc/converge/resource#StatusLevel),
    the Status will always show up as having changes

--- a/resource/docker/container/container.go
+++ b/resource/docker/container/container.go
@@ -119,9 +119,7 @@ func (c *Container) Check(context.Context, resource.Renderer) (resource.TaskStat
 		status.AddDifference("name", "", c.Name, "<container-missing>")
 	}
 
-	if resource.AnyChanges(status.Differences) {
-		status.Level = resource.StatusWillChange
-	}
+	status.RaiseLevelForDiffs()
 
 	return status, nil
 }

--- a/resource/docker/image/image.go
+++ b/resource/docker/image/image.go
@@ -51,9 +51,8 @@ func (i *Image) Check(context.Context, resource.Renderer) (resource.TaskStatus, 
 	}
 
 	status.AddDifference("image", original, repoTag, "<image-missing>")
-	if resource.AnyChanges(status.Differences) {
-		status.Level = resource.StatusWillChange
-	}
+	status.RaiseLevelForDiffs()
+
 	return status, nil
 }
 

--- a/resource/docker/network/network.go
+++ b/resource/docker/network/network.go
@@ -108,9 +108,7 @@ func (n *Network) Check(context.Context, resource.Renderer) (resource.TaskStatus
 		}
 	}
 
-	if resource.AnyChanges(status.Differences) {
-		status.RaiseLevel(resource.StatusWillChange)
-	}
+	status.RaiseLevelForDiffs()
 
 	return status, nil
 }

--- a/resource/docker/volume/volume.go
+++ b/resource/docker/volume/volume.go
@@ -83,9 +83,7 @@ func (v *Volume) Check(context.Context, resource.Renderer) (resource.TaskStatus,
 		// https://docs.docker.com/engine/reference/api/docker_remote_api_v1.24/#/inspect-a-volume
 	}
 
-	if resource.AnyChanges(status.Differences) {
-		status.RaiseLevel(resource.StatusWillChange)
-	}
+	status.RaiseLevelForDiffs()
 
 	return status, nil
 }

--- a/resource/file/fetch/fetch.go
+++ b/resource/file/fetch/fetch.go
@@ -184,7 +184,6 @@ func (f *Fetch) DiffFile(status *resource.Status, hsh hash.Hash) (*resource.Stat
 		} else if f.Force {
 			status.AddDifference("checksum", actual, f.Hash, "")
 			status.AddMessage("checksum mismatch")
-			status.RaiseLevel(resource.StatusWillChange)
 		} else {
 			status.AddMessage("checksum mismatch, use the \"force\" option to replace")
 			status.RaiseLevel(resource.StatusCantChange)
@@ -194,11 +193,12 @@ func (f *Fetch) DiffFile(status *resource.Status, hsh hash.Hash) (*resource.Stat
 		if f.Force {
 			status.AddDifference("destination", "<force fetch>", f.Destination, "")
 			status.AddMessage("file exists, will fetch due to \"force\"")
-			status.RaiseLevel(resource.StatusWillChange)
 		} else {
 			status.AddMessage("file exists")
 		}
 	}
+
+	status.RaiseLevelForDiffs()
 
 	return status, nil
 }

--- a/resource/group/group.go
+++ b/resource/group/group.go
@@ -115,7 +115,6 @@ func (g *Group) Check(context.Context, resource.Renderer) (resource.TaskStatus, 
 			case g.NewName == "":
 				switch {
 				case nameNotFound:
-					status.RaiseLevel(resource.StatusWillChange)
 					status.Output = append(status.Output, "add group")
 					status.AddDifference("group", string(StateAbsent), fmt.Sprintf("group %s", g.Name), "")
 				case groupByName != nil:
@@ -130,7 +129,6 @@ func (g *Group) Check(context.Context, resource.Renderer) (resource.TaskStatus, 
 					status.Output = append(status.Output, fmt.Sprintf("group modify: group %s does not exist", g.Name))
 					return status, errors.New("cannot modify group")
 				case newNameNotFound:
-					status.RaiseLevel(resource.StatusWillChange)
 					status.Output = append(status.Output, "modify group name")
 					status.AddDifference("group", fmt.Sprintf("group %s", g.Name), fmt.Sprintf("group %s", g.NewName), "")
 				case groupByNewName != nil:
@@ -147,7 +145,6 @@ func (g *Group) Check(context.Context, resource.Renderer) (resource.TaskStatus, 
 			case g.NewName == "":
 				switch {
 				case nameNotFound && gidNotFound:
-					status.RaiseLevel(resource.StatusWillChange)
 					status.Output = append(status.Output, "add group with gid")
 					status.AddDifference("group", string(StateAbsent), fmt.Sprintf("group %s with gid %s", g.Name, g.GID), "")
 				case nameNotFound:
@@ -155,7 +152,6 @@ func (g *Group) Check(context.Context, resource.Renderer) (resource.TaskStatus, 
 					status.Output = append(status.Output, fmt.Sprintf("group add: gid %s already exists", g.GID))
 					return status, errors.New("cannot add group")
 				case gidNotFound:
-					status.RaiseLevel(resource.StatusWillChange)
 					status.Output = append(status.Output, "modify group gid")
 					status.AddDifference("group", fmt.Sprintf("group %s with gid %s", g.Name, groupByName.Gid), fmt.Sprintf("group %s with gid %s", g.Name, g.GID), "")
 				case groupByName != nil && groupByGid != nil && groupByName.Name != groupByGid.Name || groupByName.Gid != groupByGid.Gid:
@@ -172,7 +168,6 @@ func (g *Group) Check(context.Context, resource.Renderer) (resource.TaskStatus, 
 
 				switch {
 				case newNameNotFound && gidNotFound:
-					status.RaiseLevel(resource.StatusWillChange)
 					status.Output = append(status.Output, "modify group name and gid")
 					status.AddDifference("group", fmt.Sprintf("group %s with gid %s", g.Name, groupByName.Gid), fmt.Sprintf("group %s with gid %s", g.NewName, g.GID), "")
 				case gidNotFound:
@@ -195,7 +190,6 @@ func (g *Group) Check(context.Context, resource.Renderer) (resource.TaskStatus, 
 			case nameNotFound:
 				status.Output = append(status.Output, fmt.Sprintf("group delete: group %s does not exist", g.Name))
 			case groupByName != nil:
-				status.RaiseLevel(resource.StatusWillChange)
 				status.Output = append(status.Output, "delete group")
 				status.AddDifference("group", fmt.Sprintf("group %s", g.Name), string(StateAbsent), "")
 			}
@@ -219,7 +213,6 @@ func (g *Group) Check(context.Context, resource.Renderer) (resource.TaskStatus, 
 				status.Output = append(status.Output, fmt.Sprintf("group delete: group %s and gid %s belong to different groups", g.Name, g.GID))
 				return status, errors.New("cannot delete group")
 			case groupByName != nil && groupByGid != nil && *groupByName == *groupByGid:
-				status.RaiseLevel(resource.StatusWillChange)
 				status.Output = append(status.Output, "delete group with gid")
 				status.AddDifference("group", fmt.Sprintf("group %s with gid %s", g.Name, g.GID), string(StateAbsent), "")
 			}
@@ -228,6 +221,8 @@ func (g *Group) Check(context.Context, resource.Renderer) (resource.TaskStatus, 
 		status.RaiseLevel(resource.StatusFatal)
 		return status, fmt.Errorf("group: unrecognized state %s", g.State)
 	}
+
+	status.RaiseLevelForDiffs()
 
 	return status, nil
 }

--- a/resource/lvm/fs/fs.go
+++ b/resource/lvm/fs/fs.go
@@ -80,9 +80,7 @@ func (r *resourceFS) Check(context.Context, resource.Renderer) (resource.TaskSta
 		return nil, err
 	}
 
-	if resource.AnyChanges(status.Differences) {
-		status.Level = resource.StatusWillChange
-	}
+	status.RaiseLevelForDiffs()
 
 	return status, nil
 }

--- a/resource/lvm/vg/vg.go
+++ b/resource/lvm/vg/vg.go
@@ -91,9 +91,8 @@ func (r *resourceVG) Check(context.Context, resource.Renderer) (resource.TaskSta
 		status.AddDifference(r.name, "<not exists>", strings.Join(r.devicesToAdd, ", "), "")
 	}
 
-	if resource.AnyChanges(status.Differences) {
-		status.Level = resource.StatusWillChange
-	}
+	status.RaiseLevelForDiffs()
+
 	return status, nil
 }
 

--- a/resource/status.go
+++ b/resource/status.go
@@ -280,6 +280,14 @@ func (t *Status) RaiseLevel(level StatusLevel) {
 	}
 }
 
+// RaiseLevelForDiffs raises the status level to StatusWillChange if there are
+// differences in the Differences map
+func (t *Status) RaiseLevelForDiffs() {
+	if AnyChanges(t.Differences) {
+		t.RaiseLevel(StatusWillChange)
+	}
+}
+
 // Diff represents a difference
 type Diff interface {
 	Original() string

--- a/resource/user/user.go
+++ b/resource/user/user.go
@@ -329,9 +329,7 @@ func (u *User) DiffAdd(status *resource.Status) (*AddUserOptions, error) {
 		status.AddDifference("expiry", "<default expiry>", options.Expiry, "")
 	}
 
-	if resource.AnyChanges(status.Differences) {
-		status.RaiseLevel(resource.StatusWillChange)
-	}
+	status.RaiseLevelForDiffs()
 
 	return options, nil
 }
@@ -362,9 +360,7 @@ func (u *User) DiffDel(status *resource.Status, userByName *user.User, nameNotFo
 		}
 	}
 
-	if resource.AnyChanges(status.Differences) {
-		status.RaiseLevel(resource.StatusWillChange)
-	}
+	status.RaiseLevelForDiffs()
 
 	return nil
 }
@@ -459,9 +455,7 @@ func (u *User) DiffMod(status *resource.Status, currUser *user.User) (*ModUserOp
 		}
 	}
 
-	if resource.AnyChanges(status.Differences) {
-		status.RaiseLevel(resource.StatusWillChange)
-	}
+	status.RaiseLevelForDiffs()
 
 	return options, nil
 }


### PR DESCRIPTION
A new method on status `RaiseLevelForDiffs` checks if there are any diffs and raises the level to `StatusWillChange`.
Resources were updated to call this new method in the following cases:
- The same check was being performed prior to raising the level to `StatusWillChange`
- Multiple calls to `AddDifference`/`RaiseLevel` to `StatusWillChange`: the calls to `RaiseLevel` were removed and a call to this new method was added at the end of the function.

Implements #586 